### PR TITLE
chore: Refactor shareTrackByID method in ShareService oc: 3850

### DIFF
--- a/core/src/app/pages/map/map.page.ts
+++ b/core/src/app/pages/map/map.page.ts
@@ -457,12 +457,7 @@ export class MapPage implements OnInit, OnDestroy {
   }
 
   openTrackShare(trackId: number): void {
-    this.confAPP$.pipe(take(1)).subscribe(conf => {
-      this._shareSvc.shareTrackByID({
-        id: trackId,
-        text: this._wmTrans.transform(conf.socialShareText),
-      });
-    });
+    this._shareSvc.shareTrackByID(trackId);
   }
 
   openPoiShare(poiId: number): void {

--- a/core/src/app/services/config.service.ts
+++ b/core/src/app/services/config.service.ts
@@ -15,6 +15,7 @@ import {environment} from 'src/environments/environment';
 import pkg from 'package.json';
 import {timeout} from 'rxjs/operators';
 import {IConfig} from 'wm-core/types/config';
+import { hostToGeohubAppId } from 'wm-core/store/api/api.service';
 
 @Injectable({
   providedIn: 'root',
@@ -22,15 +23,6 @@ import {IConfig} from 'wm-core/types/config';
 export class ConfigService {
   private _config: IConfig;
   private _geohubAppId: number = environment.geohubId;
-  private _hostToGeohubAppId: { [key: string]: number } = {
-    'sentieri.caiparma.it': 33,
-    'motomappa.motoabbigliamento.it': 53,
-    'maps.parcoforestecasentinesi.it': 49,
-    'maps.parcopan.org': 63,
-    'maps.acquasorgente.cai.it': 58,
-    'maps.caipontedera.it': 59,
-    'maps.parcapuane.it': 62,
-  };
 
   get appId(): string {
     return this._config.APP.id ? this._config.APP.id : 'it.webmapp.webmapp';
@@ -121,11 +113,11 @@ export class ConfigService {
           const hostname: string = window.location.hostname;
           this._geohubAppId = parseInt(hostname.split('.')[0], 10) || 4;
           if (hostname.indexOf('localhost') < 0) {
-            const matchedHost = Object.keys(this._hostToGeohubAppId).find(host =>
+            const matchedHost = Object.keys(hostToGeohubAppId).find(host =>
               hostname.includes(host),
             );
             if (matchedHost) {
-              this._geohubAppId = this._hostToGeohubAppId[matchedHost];
+              this._geohubAppId = hostToGeohubAppId[matchedHost];
             } else {
               const newGeohubId = parseInt(hostname.split('.')[0], 10);
               if (!Number.isNaN(newGeohubId)) {

--- a/core/src/app/services/share.service.ts
+++ b/core/src/app/services/share.service.ts
@@ -39,7 +39,6 @@ export class ShareService {
       ])
       .subscribe(t => {
         this.defaultShareObj.title = t['services.share.title'];
-        this.defaultShareObj.text = '';
         this.defaultShareObj.url = t['services.share.url'];
         this.defaultShareObj.dialogTitle = t['services.share.dialogTitle'];
       });

--- a/core/src/app/services/share.service.ts
+++ b/core/src/app/services/share.service.ts
@@ -24,8 +24,13 @@ export class ShareService {
     url: 'www.webmapp.it',
     dialogTitle: 'Share with buddies',
   };
+  private _host;
+  private _baseLink;
 
   constructor(private _translate: LangService, private _confSvc: ConfService) {
+    this._host = this._confSvc.getHost();
+    this._baseLink = (this._host) ? this._host : `${this._confSvc.geohubAppId}.app.webmapp.it`;
+
     this._translate
       .get([
         'services.share.title',
@@ -55,26 +60,23 @@ export class ShareService {
     );
   }
 
-  public async shareRoute(route: IGeojsonFeature) {
+  public async shareRoute(route: IGeojsonFeature): Promise<void> {
     return this.share({
       url: `${DEFAULT_ROUTE_LINK_BASEURL}${route.properties.id}`,
     });
   }
 
-  public async shareTrackByID(shareObj: ShareObject) {
-    shareObj = {
-      ...shareObj,
-      ...{url: `${DEFAULT_ROUTE_LINK_BASEURL}${shareObj.id}?app_id=${this._confSvc.geohubAppId}`},
-    };
-    return this.share(shareObj);
-  }
-
-  public async sharePoiByID(poiId: number){
-    const host = this._confSvc.getHost();
-    const base_link = (host) ? host : `${this._confSvc.geohubAppId}.app.webmapp.it`;
+  public shareTrackByID(trackId: number): void {
     this.share({
       text: '',
-      url: `https://${base_link}/map?poi=${poiId}`,
+      url: `https://${this._baseLink}/map?track=${trackId}`,
+    });
+  }
+
+  public sharePoiByID(poiId: number): void{
+    this.share({
+      text: '',
+      url: `https://${this._baseLink}/map?poi=${poiId}`,
     })
   }
 }

--- a/core/src/app/services/share.service.ts
+++ b/core/src/app/services/share.service.ts
@@ -20,7 +20,7 @@ export interface ShareObject {
 export class ShareService {
   private defaultShareObj: ShareObject = {
     title: 'See cool stuff',
-    text: 'Really awesome thing you need to see right meow',
+    text: '',
     url: 'www.webmapp.it',
     dialogTitle: 'Share with buddies',
   };
@@ -34,13 +34,12 @@ export class ShareService {
     this._translate
       .get([
         'services.share.title',
-        'services.share.text',
         'services.share.url',
         'services.share.dialogTitle',
       ])
       .subscribe(t => {
         this.defaultShareObj.title = t['services.share.title'];
-        this.defaultShareObj.text = t['services.share.text'];
+        this.defaultShareObj.text = '';
         this.defaultShareObj.url = t['services.share.url'];
         this.defaultShareObj.dialogTitle = t['services.share.dialogTitle'];
       });
@@ -68,14 +67,12 @@ export class ShareService {
 
   public shareTrackByID(trackId: number): void {
     this.share({
-      text: '',
       url: `https://${this._baseLink}/map?track=${trackId}`,
     });
   }
 
   public sharePoiByID(poiId: number): void{
     this.share({
-      text: '',
       url: `https://${this._baseLink}/map?poi=${poiId}`,
     })
   }


### PR DESCRIPTION
The shareTrackByID method in the ShareService has been refactored to simplify the code and improve readability. Instead of subscribing to an observable and transforming the socialShareText, it now directly shares the track by calling the share method with the trackId as a parameter. This change reduces unnecessary complexity and improves performance.

chore: Update hostToGeohubAppId in ConfigService

The hostToGeohubAppId object in the ConfigService has been updated to use the imported hostToGeohubAppId from 'wm-core/store/api/api.service' instead of the previous hardcoded values. This change allows for more flexibility and easier maintenance of the geohub app IDs based on the hostname.
