### PR TITLE
fix: Add dynamic title for UGC POI properties in map page oc:4647

### DIFF
--- a/core/src/app/pages/map/map.page.html
+++ b/core/src/app/pages/map/map.page.html
@@ -40,6 +40,9 @@
           <ion-title *ngIf="!(currentPoiProperties$|async) && currentTrack$|async as currentTrack;">
             {{currentTrack?.properties?.name|wmtrans }}
           </ion-title>
+          <ion-title *ngIf="(currentUgcPoiProperties$|async) as ugcPoiProperties">
+            {{ugcPoiProperties.name|wmtrans}}
+          </ion-title>
         </div>
       </div>
 


### PR DESCRIPTION
- Added an *ngIf condition to display the title based on the presence of currentUgcPoiProperties$.
- The title now shows the name of the UGC POI properties using wmtrans translation.

This commit enhances the map page by dynamically displaying a title for UGC POI properties when available.
