### PR TITLE
chore: Remove unnecessary trackElevationChartHover event listener oc: 4820

### DIFF
--- a/core/src/app/pages/map/map.page.html
+++ b/core/src/app/pages/map/map.page.html
@@ -62,7 +62,6 @@
       </ng-container>
       <ng-template #ecTrack>
         <wm-track-properties
-          (trackElevationChartHover)="setTrackElevationChartHoverElements($event)"
           (dismiss)="updateEcTrack()"
           (click)="savePosition()"
           class="webmapp-track-details"
@@ -91,7 +90,6 @@
         <wm-ugc-track-properties
           *ngIf="(ugcTrack$|async) as ugcTrack"
           [track]="ugcTrack"
-          (trackElevationChartHover)="setTrackElevationChartHoverElements($event)"
           (poi-click)="setCurrentRelatedPoi($event)"
         ></wm-ugc-track-properties>
       </ng-template>


### PR DESCRIPTION
The code changes in this commit involve removing the trackElevationChartHover event listener from two templates in the map.page.html file. This event listener is no longer needed and has been causing unnecessary overhead.
