### PR TITLE
chore: Update map-details component styles and logic oc: 4832

### DIFF
--- a/core/src/app/pages/map/map-details/map-details.component.scss
+++ b/core/src/app/pages/map/map-details/map-details.component.scss
@@ -81,6 +81,10 @@ wm-map-details {
       overflow-x: hidden;
       padding: 0 !important;
       margin: 0 !important;
+
+      wm-poi-properties {
+        position: relative;
+      }
     }
   }
 }

--- a/core/src/app/pages/map/map-details/map-details.component.ts
+++ b/core/src/app/pages/map/map-details/map-details.component.ts
@@ -36,7 +36,7 @@ export class MapDetailsComponent implements AfterViewInit {
   height = 700;
   isOpen$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
   maxInfoheight = 850;
-  minInfoheight = 350;
+  minInfoheight = 320;
   modeFullMap = false;
   stepStatus = 0;
 
@@ -99,7 +99,7 @@ export class MapDetailsComponent implements AfterViewInit {
   }
 
   open(): void {
-    this.setAnimations(`${this._getCurrentHeight()}px`, `${320}px`);
+    this.setAnimations(`${this._getCurrentHeight()}px`, `${this.minInfoheight}px`);
     this.isOpen$.next(true);
   }
 
@@ -137,12 +137,6 @@ export class MapDetailsComponent implements AfterViewInit {
     this.toggleEVT.emit();
   }
 
-  private _clamp(min: number, n: number, max: number): number {
-    const val = Math.max(min, Math.min(n, max));
-    this.stepStatus = val;
-    return this.stepStatus;
-  }
-
   private _getCurrentHeight(): number {
     return this._elRef.nativeElement.offsetHeight;
   }
@@ -155,7 +149,7 @@ export class MapDetailsComponent implements AfterViewInit {
       onStart: ev => {
         this.toggleEVT.emit();
 
-        if (this._getCurrentHeight() > this.maxInfoheight / 2 || this._getCurrentHeight() === 56) {
+        if (this._getCurrentHeight() > this.minInfoheight || this._getCurrentHeight() === 56) {
           this.open();
         } else {
           this.full();
@@ -172,29 +166,5 @@ export class MapDetailsComponent implements AfterViewInit {
       this._gesture.enable(true);
     });
     this.stepStatus = shouldComplete ? 0 : 1;
-  }
-
-  private getStep(ev) {
-    const delta = this._initialStep - ev.deltaY;
-    return this._clamp(0, delta / (this.maxInfoheight - this.minInfoheight), 1);
-  }
-
-  private onEnd(ev) {
-    if (!this._started) {
-      return;
-    }
-    this._gesture.enable(false);
-    const step = this.getStep(ev);
-    const shouldComplete = step > 0.5;
-    this.endAnimation(shouldComplete, step);
-  }
-
-  private onMove(ev) {
-    if (!this._started) {
-      this._animationSwipe.progressStart(false);
-      this._started = true;
-    }
-    const step = this.getStep(ev);
-    this._animationSwipe.progressStep(step);
   }
 }

--- a/core/src/app/pages/map/map.page.html
+++ b/core/src/app/pages/map/map.page.html
@@ -56,9 +56,7 @@
         [enableDismiss]="false"
       ></wm-inner-component-html>
       <ng-container *ngIf="currentPoiProperties$|async as properties; else ecTrack">
-        <ion-content class="webmapp-pagepoi-info-body" scrollY="true">
           <wm-poi-properties [properties]="properties" *ngIf="properties!=null"></wm-poi-properties>
-        </ion-content>
       </ng-container>
       <ng-template #ecTrack>
         <wm-track-properties

--- a/core/src/app/pages/map/map.page.scss
+++ b/core/src/app/pages/map/map.page.scss
@@ -111,49 +111,6 @@ webmapp-map-page {
       }
     }
   }
-  .webmapp-pagepoi-info-container {
-    position: absolute;
-    display: block;
-    bottom: 0;
-    height: 50%;
-    border-radius: 15px;
-    background: white;
-    width: 100%;
-    height: 100%;
-    padding: 10px;
-    z-index: 2;
-
-    .webmapp-pagepoi-info-body {
-      --padding-bottom: 30px;
-      .webmapp-pagepoi-info-reference {
-        padding: 3px 5px;
-        font-size: var(--wm-font-sm);
-        a {
-          text-decoration: none;
-          color: var(--wm-color-dark);
-        }
-        .webmapp-pagepoi-info-icon {
-          color: var(--wm-color-primary);
-        }
-      }
-      .webmapp-pagepoi-info-body-photoslider {
-        padding: 10px 0;
-        overflow: visible;
-        .webmapp-pagepoi-info-body-photo {
-          height: 150px;
-          width: 250px;
-          &::part(image) {
-            border-radius: 15px;
-          }
-        }
-      }
-    }
-  }
-  .webmapp-pagepoi-info-body-description {
-    padding: 10px 0;
-    margin-bottom: 10%;
-  }
-
   ion-title {
     font-size: unset;
   }


### PR DESCRIPTION
- Added position relative to wm-poi-properties in the component's SCSS file
- Updated minInfoheight value from 350px to 320px in the component's TypeScript file
- Refactored setAnimations method to use minInfoheight instead of hardcoded value

chore: Remove unnecessary code from map page

- Removed unused ion-content element in map.page.html
- Removed webmapp-pagepoi-info-container styles from map.page.scss
