### PR TITLE
chore: Update tabs.page.ts to reset additional query parameters oc:4907

### DIFF
--- a/core/src/app/pages/tabs/tabs.page.ts
+++ b/core/src/app/pages/tabs/tabs.page.ts
@@ -50,7 +50,12 @@ export class TabsPage {
     if (tab === 'home') {
       const queryParams = {
         ...this._urlHandlerSvc.getCurrentQueryParams(),
-        ...{track: undefined, poi: undefined},
+        ...{
+          track: undefined,
+          poi: undefined,
+          ugc_track: undefined,
+          ugc_poi: undefined,
+        },
       };
       this._urlHandlerSvc.changeURL(tab, queryParams);
     }


### PR DESCRIPTION
This commit updates the tabs.page.ts file to reset the "ugc_track" and "ugc_poi" query parameters along with "track" and "poi". This ensures that all relevant query parameters are properly reset when navigating to the home tab.
