### PR TITLE
chore: add e2e test for downloading ec-track oc: 4974

### DIFF
--- a/core/cypress/e2e/app_52/download-ec-track.cy.ts
+++ b/core/cypress/e2e/app_52/download-ec-track.cy.ts
@@ -23,7 +23,7 @@ describe('Download ec-track', () => {
 
   it('Should visualize the download track', () => {
     getGoToDownloadsButton().click();
-    cy.get('wm-search-box').contains('ion-card-title', 'Track example one').should('exist');
+    cy.get('wm-search-box').contains('ion-card-title', data.tracks.exampleOne).should('exist');
   });
 });
 
@@ -32,5 +32,5 @@ function getDownloadButton() {
 }
 
 function getGoToDownloadsButton() {
-  return cy.get('wm-download ion-button.webmapp-downloadpanel-button', {timeout: 10000});
+  return cy.get('wm-download ion-button.webmapp-downloadpanel-button', {timeout: 7000});
 }

--- a/core/cypress/e2e/app_52/download-ec-track.cy.ts
+++ b/core/cypress/e2e/app_52/download-ec-track.cy.ts
@@ -1,0 +1,36 @@
+import {openLayer, openTrack, data} from 'cypress/utils/test-utils';
+
+describe('Download ec-track', () => {
+  before(() => {
+    cy.clearLocalStorage();
+    cy.visit('/');
+  });
+
+  it('Should visualize ec-track download button', () => {
+    openLayer(data.layers.ecTrack);
+    openTrack(data.tracks.exampleOne);
+
+    getDownloadButton().should('exist');
+  });
+
+  it('Should download ec-track', () => {
+    getDownloadButton().click();
+
+    cy.get('wm-download').should('exist');
+
+    getGoToDownloadsButton().should('exist').as('downloadButton');
+  });
+
+  it('Should visualize the download track', () => {
+    getGoToDownloadsButton().click();
+    cy.get('wm-search-box').contains('ion-card-title', 'Track example one').should('exist');
+  });
+});
+
+function getDownloadButton() {
+  return cy.get('ion-fab-button:has(ion-icon[name="download-outline"])');
+}
+
+function getGoToDownloadsButton() {
+  return cy.get('wm-download ion-button.webmapp-downloadpanel-button', {timeout: 10000});
+}


### PR DESCRIPTION
This commit adds a new e2e test file `download-ec-track.cy.ts` that tests the functionality of downloading an ec-track. The test verifies that the download button is visible, downloads the track, and checks if the downloaded track is displayed correctly in the downloads section.

The test uses helper functions `getDownloadButton()` and `getGoToDownloadsButton()` to locate and interact with the relevant elements on the page.

These changes aim to ensure that the download feature for ec-tracks is working as expected.
