### PR TITLE
chore: Add tests for favorites functionality oc:4990

### DIFF
--- a/core/cypress/e2e/app_52/favourites.cy.ts
+++ b/core/cypress/e2e/app_52/favourites.cy.ts
@@ -1,0 +1,58 @@
+import {
+  clearTestState,
+  data,
+  e2eLogin,
+  goHome,
+  openLayer,
+  openTrack,
+} from 'cypress/utils/test-utils';
+import {environment} from 'src/environments/environment';
+
+const confURL = `${environment.awsApi}/conf/52.json`;
+
+before(() => {
+  clearTestState();
+  cy.intercept('GET', confURL, req => {
+    req.reply(res => {
+      const newRes = {
+        ...res.body,
+        AUTH: {
+          ...res.body.AUTH,
+          enable: true,
+          webappEnable: true,
+        },
+      };
+      res.send(newRes);
+    });
+  }).as('getConf');
+  cy.visit('/');
+});
+
+describe('Favourites', () => {
+  it('Should favorites button not visible if not logged in', () => {
+    openLayer(data.layers.ecTrack);
+    openTrack(data.tracks.exampleOne);
+
+    cy.get('ion-fab-button:has(.icon-outline-heart)').should('not.exist');
+  });
+
+  it('Should favorites button visible if logged in', () => {
+    e2eLogin();
+    cy.get('ion-alert button').click();
+    goHome();
+    openLayer(data.layers.ecTrack);
+    openTrack(data.tracks.exampleOne);
+
+    cy.get('ion-fab-button:has(.icon-outline-heart)').should('exist');
+  });
+
+  it('Should add to favorites', () => {
+    cy.get('ion-fab-button:has(.icon-outline-heart)').click();
+    cy.get('ion-fab-button:has(.icon-fill-heart)').should('exist');
+  });
+
+  it('Should remove from favorites', () => {
+    cy.get('ion-fab-button:has(.icon-fill-heart)').click();
+    cy.get('ion-fab-button:has(.icon-outline-heart)').should('exist');
+  });
+});


### PR DESCRIPTION
This commit adds test cases to verify the behavior of the favorites button in the application. The tests cover scenarios where the button is not visible if the user is not logged in, and where it is visible after logging in. Additionally, there are tests to ensure that adding and removing items from favorites works correctly.

The changes include adding a new file `favourites.cy.ts` which contains the test code.
