### PR TITLE
chore: add import UGC test oc:5009

### DIFF
--- a/core/cypress/e2e/app_52/import-ugc.cy.ts
+++ b/core/cypress/e2e/app_52/import-ugc.cy.ts
@@ -1,0 +1,41 @@
+import {clearTestState, confWithAuthEnabled, e2eLogin, goHome} from 'cypress/utils/test-utils';
+const fileToImport = 'trackToImport.geojson';
+
+describe('Import UGC', () => {
+  before(() => {
+    clearTestState();
+    confWithAuthEnabled().as('getConf');
+    cy.visit('/');
+  });
+
+  it('Should open import UGC', () => {
+    e2eLogin();
+    cy.get('ion-alert button').click();
+    goHome();
+    cy.get('wm-ugc-box').click();
+    cy.get('wm-home-ugc wm-ugc-box ion-button').click();
+
+    cy.get('input[type="file"]').selectFile(`cypress/fixtures/${fileToImport}`, {force: true});
+  });
+
+  it('Should visualize preview map', () => {
+    cy.get('ion-content ion-item ion-label').contains('p', fileToImport);
+    cy.get('ion-content wm-map').should('exist');
+  });
+
+  it('Should pre-populate the form', () => {
+    cy.get('ion-item.wm-form-field')
+      .contains('Track title')
+      .parent()
+      .find('ion-input input')
+      .invoke('val')
+      .should('not.be.empty');
+
+    cy.get('ion-item.wm-form-field')
+      .contains('Description')
+      .parent()
+      .find('ion-textarea textarea')
+      .invoke('val')
+      .should('not.be.empty');
+  });
+});


### PR DESCRIPTION
This commit adds a new test for importing user-generated content (UGC). The test includes steps to open the import UGC feature, select a file to import, visualize a preview map, and pre-populate the form with track title and description.
