### PR TITLE
chore: add login offline e2e test oc:5010

### DIFF
--- a/core/cypress/e2e/app_52/login-offline.cy.ts
+++ b/core/cypress/e2e/app_52/login-offline.cy.ts
@@ -1,0 +1,31 @@
+import {clearTestState, confWithAuthEnabled, e2eLogin, goProfile} from 'cypress/utils/test-utils';
+import {environment} from 'src/environments/environment';
+
+const meUrl = `${environment.api}/api/auth/me`;
+
+describe('Login offline', () => {
+  before(() => {
+    clearTestState();
+    confWithAuthEnabled().as('getConf');
+    cy.visit('/');
+  });
+
+  it('Should login online', () => {
+    e2eLogin();
+    cy.get('ion-alert button').click();
+  });
+
+  it('Should login offline', () => {
+    cy.intercept('POST', meUrl, req => {
+      req.reply(res => {
+        res.send({
+          statusCode: 500,
+        });
+      });
+    }).as('meOffline');
+    cy.reload();
+    cy.wait('@meOffline');
+    goProfile();
+    cy.get('wm-profile-user').should('not.be.empty');
+  });
+});


### PR DESCRIPTION
This commit adds a new e2e test for logging in offline. The test includes scenarios for logging in online and offline, as well as handling server errors.
