### PR TITLE
chore: add translations oc: 5066

### DIFF
--- a/core/src/assets/i18n/de.json
+++ b/core/src/assets/i18n/de.json
@@ -1,0 +1,602 @@
+{
+  "activities": {
+    "cycling": "Radfahren",
+    "hiking": "Wandern",
+    "running": "Laufen",
+    "skitouring": "Skitour",
+    "walking": "Spazieren",
+    "asphalt": "Asphalt",
+    "bitumenduro": "Bitumenduro",
+    "onoff": "On/Off",
+    "real-dirt": "Echter Schmutz",
+    "bar": "Bar"
+  },
+  "sidemenu": {
+    "project": "Projekt",
+    "offline": "Offline",
+    "settings": "Einstellungen",
+    "credits": "Credits",
+    "disclaimer": "Haftungsausschluss"
+  },
+  "components": {
+    "cardtrack": {
+      "delete": "Löschen",
+      "remove": "Entfernen"
+    },
+    "map": {
+      "btnrec": {
+        "slide": "Zum Aufnehmen wischen"
+      },
+      "register": {
+        "cancel": "Abbrechen",
+        "photo": "Foto",
+        "title": "Aufzeichnen",
+        "track": "Strecke",
+        "vocal": "Sprachnotiz",
+        "waypoint": "Wegpunkt"
+      }
+    },
+    "searchbar": {
+      "filters": "Filtern nach",
+      "nofilters": "Keine Filter entsprechen der durchgeführten Suche",
+      "noplaces": "Keine Orte entsprechen der durchgeführten Suche",
+      "notracks": "Keine Strecken entsprechen der durchgeführten Suche",
+      "placeholder": "suchen",
+      "places": "Orte",
+      "tracks": "Strecken"
+    },
+    "slopechart": {
+      "slope": {
+        "label": "Steigung"
+      },
+      "surfaces": {
+        "asphalt": {
+          "label": "Asphalt"
+        },
+        "concrete": {
+          "label": "Beton"
+        },
+        "dirt": {
+          "label": "Erde"
+        },
+        "grass": {
+          "label": "Gras"
+        },
+        "gravel": {
+          "label": "Kies"
+        },
+        "paved": {
+          "label": "Gepflastert"
+        },
+        "sand": {
+          "label": "Sand"
+        }
+      }
+    }
+  },
+  "generic": {
+    "cancel": "abbrechen",
+    "confirm": "bestätigen",
+    "delete": "löschen",
+    "error": "Ein Fehler ist aufgetreten. Bitte versuchen Sie es später erneut",
+    "hour": "Stunde",
+    "minute": "Min",
+    "ok": "ok",
+    "retry": "erneut versuchen",
+    "warning": "Achtung"
+  },
+  "modals": {
+    "coin": {
+      "buttonall": "Alle Münzpakete anzeigen",
+      "buttonone": "1 Münze kaufen / 1€",
+      "defaultmessage": "Kaufen Sie Münzen, um Offline-Inhalte herunterzuladen",
+      "info1": "Sie können eine einzelne Strecke kaufen",
+      "info2": "Alles ist auch ohne Abdeckung verfügbar",
+      "info3": "Erhalten Sie Benachrichtigungen bei Annäherung",
+      "subinfo1": "Kaufen Sie eine einzelne Münze für 1€",
+      "subinfo2": "Präzise Navigation auch offline",
+      "subinfo3": "Wir benachrichtigen Sie in der Nähe von Interessenspunkten auf der Strecke"
+    },
+    "giftcoin": {
+      "button": "Beginnen Sie zu erkunden",
+      "info": "Sie erhalten sofort 2 Webmapp-Münzen als Geschenk, um Offline-Inhalte herunterzuladen!",
+      "title": "Willkommen bei Webmapp!"
+    },
+    "login": {
+      "email": "E-Mail",
+      "errors": {
+        "401": "Die eingegebenen Anmeldedaten sind nicht korrekt. Bitte überprüfen Sie E-Mail und Passwort und versuchen Sie es erneut",
+        "form": {
+          "emailInvalid": "Sie haben eine ungültige E-Mail-Adresse eingegeben",
+          "emailRequired": "E-Mail ist erforderlich",
+          "passwordRequired": "Passwort ist erforderlich"
+        },
+        "generic": "Oops! Etwas ist schief gelaufen! Bitte warten Sie einige Minuten und versuchen Sie es erneut."
+      },
+      "forgotPassword": "Passwort vergessen?",
+      "login": "Anmelden",
+      "message": "Melden Sie sich mit Ihren Anmeldedaten an, um fortzufahren.",
+      "password": "Passwort",
+      "rememberLogin": "Anmeldedaten merken",
+      "title": "Anmelden",
+      "welcome": "Willkommen zurück!"
+    },
+    "photo": {
+      "next": "Weiter",
+      "popover": {
+        "cancel": "Abbrechen",
+        "library": "Aus der Bibliothek",
+        "shot": "Ein Foto machen",
+        "title": "Bildquelle"
+      },
+      "save": {
+        "addphoto": "Foto hinzufügen",
+        "formphototitle": "Titel ",
+        "formtitle": "Geben Sie Ihren Fotos einen Titel",
+        "modalconfirm": {
+          "cancel": "Abbrechen",
+          "confirm": "Ja, löschen",
+          "text": "Wenn Sie es löschen, wird es nicht zu dieser Aufzeichnung hinzugefügt",
+          "title": "Sind Sie sicher, dass Sie dieses Foto aus der Aufzeichnung löschen möchten?"
+        },
+        "placeholder": "Hier können Sie einen Titel eingeben",
+        "savebtn": "Speichern",
+        "title": "Foto aufzeichnen"
+      },
+      "single": {
+        "formphototitle": "Titel",
+        "placeholder": "Hier können Sie einen Titel eingeben",
+        "savebtn": "Fertig",
+        "title": "Foto bearbeiten"
+      }
+    },
+    "settings": {
+      "alert": {
+        "logout": "Sind Sie sicher, dass Sie sich von Ihrem Konto abmelden möchten?"
+      },
+      "logout": "Abmelden",
+      "title": "Einstellungen",
+      "version": "Version"
+    },
+    "storesuccess": {
+      "back": "Zurück zur Suche",
+      "buttondownload": "Jetzt herunterladen",
+      "continue": "Möchten Sie Ihre Münze sofort verwenden, um herunterzuladen ",
+      "continue2": "?",
+      "info": "Sie können Ihr Münzguthaben direkt in Ihrem persönlichen Bereich überprüfen!",
+      "or": "Oder",
+      "title": "Vielen Dank für den Kauf Ihrer ersten Münze!"
+    },
+    "success": {
+      "photos": {
+        "text": "Ihre Fotos wurden erfolgreich gespeichert. Sie können sie anzeigen, indem Sie Ihr Profil aufrufen.",
+        "title": "Fotos erfolgreich aufgezeichnet!"
+      },
+      "return": "Zurück zum Erkunden",
+      "track": {
+        "avgspeed": "Durchschnittsgeschwindigkeit",
+        "odo": "Zurückgelegte Km",
+        "slope": "Höhenunterschied",
+        "text": "Die Strecken wurden erfolgreich gespeichert. Sie können sie anzeigen, indem Sie Ihr Profil aufrufen.",
+        "time": "Zeit",
+        "title": "Aktivität erfolgreich aufgezeichnet!",
+        "topspeed": "Höchstgeschwindigkeit"
+      },
+      "waypoint": {
+        "text": "Sie haben Ihren Wegpunkt erfolgreich gespeichert. Sie können ihn anzeigen, indem Sie Ihr Profil aufrufen.",
+        "title": "Wegpunkt erfolgreich aufgezeichnet!"
+      }
+    }
+  },
+  "pages": {
+    "downloadlist": {
+      "cancel": "Abbrechen",
+      "deleteselected": "Ausgewählte löschen",
+      "nodata": "Sie haben noch keine Strecke heruntergeladen",
+      "nodata2": "Mit Inhalten für die Offline-Nutzung navigieren Sie auch ohne Verbindung sicher!",
+      "nodatabtn": "Erkunden",
+      "select": "Auswählen",
+      "title": "Downloads"
+    },
+    "favourites": {
+      "nodata": "Es gibt keine Favoritenstrecken, klicken Sie auf das Herzsymbol einer Strecke, um sie zu dieser Liste hinzuzufügen",
+      "title": "Favoriten"
+    },
+    "home": {
+      "button": "Wählen Sie einen Startpunkt",
+      "closerTracks": "Nahe Strecken",
+      "intro": "Planen wir gemeinsam Ihr nächstes Abenteuer",
+      "mostViewedTracks": "Meistgesehene Strecken",
+      "nocloserTracks": "Es scheint, dass es keine Strecken in der Nähe Ihres aktuellen Standorts gibt",
+      "welcome": "Willkommen!"
+    },
+    "itinerary": {
+      "btnFullMapExpand": "Erweitern",
+      "btnFullMapReduce": "Reduzieren",
+      "btndnavigate": "Navigieren",
+      "btndownload": "Herunterladen",
+      "btnfavourite": "Favoriten",
+      "btnshare": "Teilen",
+      "description": {
+        "description": "Beschreibung",
+        "gallery": "Galerie"
+      },
+      "detail": {
+        "ascent": "Höhenunterschied +",
+        "descent": "Höhenunterschied -",
+        "distance": "Distanz",
+        "ele_from": "Start-Höhe",
+        "ele_max": "Maximale Höhe",
+        "ele_min": "Minimale Höhe",
+        "ele_to": "Ziel-Höhe"
+      },
+      "directions": "Wegbeschreibung erhalten",
+      "download": "Herunterladen",
+      "downloadpanel": {
+        "complete": "Download abgeschlossen",
+        "dontclose": "Schließen Sie die App nicht während der Dateninstallation",
+        "downdata": "Daten werden heruntergeladen",
+        "download": "Herunterladen",
+        "downloadbtn": "Herunterladen",
+        "downloading": "Wird heruntergeladen",
+        "downmap": "Karte wird heruntergeladen",
+        "downmedia": "Medien werden heruntergeladen",
+        "downsetup": "Erstkonfiguration",
+        "gotobtn": "Zu meinen Downloads gehen",
+        "install": "Installation"
+      },
+      "favbtn": {
+        "isFavourite": "Zu Favoriten hinzugefügt!",
+        "isNotFavourite": "Aus Favoriten entfernt!"
+      },
+      "modalconfirm": {
+        "cancel": "Abbrechen",
+        "confirm": "Beenden",
+        "text": "Beenden, ohne den Streckendownload abzuschließen?",
+        "title": "Download unterbrechen?"
+      },
+      "modalNotImpemented": {
+        "text": "Bald verfügbar",
+        "title": "Derzeit nicht verfügbar",
+        "confirm": "ok"
+      },
+      "navigate": "Navigieren",
+      "share": "Teilen",
+      "tabdescription": "Beschreibung",
+      "tabdetail": "Details",
+      "tabeat": "Wo essen",
+      "tabhowto": "Wie man hinkommt",
+      "tabviability": "Befahrbarkeit",
+      "tabwalkable": "Zugänglichkeit",
+      "viability": {
+        "info": "Weitere Informationen",
+        "title": "Befahrbarkeit der Strecke"
+      }
+    },
+    "map": {
+      "loading": "wird gesucht...",
+      "recordingbtn": "Aufnahme läuft",
+      "searchherebtn": "In diesem Bereich suchen"
+    },
+    "photodetail": {
+      "delete": "Aufzeichnung löschen",
+      "edit": "Aufzeichnung bearbeiten",
+      "title": "Aufgezeichnetes Foto"
+    },
+    "photolist": {
+      "noitem": "Derzeit sind keine Fotos aufgezeichnet",
+      "title": "Aufgezeichnete Fotos"
+    },
+    "profile": {
+      "data": {
+        "data": "Datennutzung",
+        "downloads": "Downloads",
+        "tracks": "Heruntergeladene Strecken"
+      },
+      "loggedOut": {
+        "login": "Anmelden",
+        "signup": "Registrieren",
+        "slides": {
+          "0": "Melden Sie sich an und laden Sie Ihre Lieblingsstrecken herunter",
+          "1": "Sie können sie auch mit Ihren Reisefreunden teilen"
+        }
+      },
+      "records": {
+        "photos": "Fotos",
+        "title": "Aufzeichnungen",
+        "tracks": "Strecken",
+        "vocals": "Sprachnotizen",
+        "waypoints": "Wegpunkte"
+      },
+      "title": "Profil",
+      "lang": "Sprache",
+      "langPlaceholder": "wählen",
+      "projectlink": "Projekt",
+      "disclaimerlink": "Haftungsausschluss",
+      "creditslink": "Credits",
+      "privacylink": "Datenschutz"
+    },
+    "register": {
+      "averagespeed": "Durchschnittsgeschwindigkeit",
+      "backgroundbtn": "Im Hintergrund aufzeichnen",
+      "currentspeed": "Aktuelle Geschwindigkeit",
+      "modalconfirm": {
+        "cancel": "Abbrechen",
+        "confirm": "Bestätigen",
+        "text": "Sobald bestätigt, können Sie diese Navigation nicht mehr neu starten",
+        "title": "Bestätigen Sie, dass Sie die Aufzeichnung beenden möchten?"
+      },
+      "modalexit": {
+        "cancel": "Abbrechen",
+        "confirm": "Löschen",
+        "text": "Durch das Beenden der Aktion wird die Strecke aus Ihrem Profil und von Webmapp gelöscht. Der Vorgang kann nicht rückgängig gemacht werden.",
+        "title": "Dauerhaft löschen?"
+      },
+      "modalphotos": {
+        "deselectall": "Alle abwählen",
+        "noimages": "Keine Bilder während der Streckenaufzeichnung aufgenommen",
+        "savebtn": "Hochladen",
+        "selectall": "Alle auswählen",
+        "title": "Fotos hochladen"
+      },
+      "modalsave": {
+        "closemodal": {
+          "back": "Zurück zur Aufzeichnung",
+          "cancel": "Abbrechen",
+          "delete": "Aufzeichnung löschen"
+        },
+        "deletebtn": "OHNE SPEICHERN BEENDEN",
+        "formactivity": "Aktivitätstyp",
+        "formactivityerror": "Der Aktivitätstyp ist ein Pflichtfeld",
+        "formactivityplaceholder": "Wählen",
+        "formdescription": "Beschreibung",
+        "formdescriptionplaceholder": "Wenn Sie möchten, können Sie eine Beschreibung hinzufügen",
+        "formphotos": "Fotos hinzufügen, die während der Strecke aufgenommen wurden",
+        "formtitle": "Titel der Strecke",
+        "formtitleerror": "Das Titelfeld ist erforderlich",
+        "formtitleplaceholder": "Geben Sie einen Titel ein",
+        "photoaction": "Hochladen",
+        "photoactionshort": "Hinzufügen",
+        "photoadvice": "Maximale Größe: 3 Fotos",
+        "photoadviceshort": "(max 3 Fotos)",
+        "phototext": "Fotos aus der Telefonbibliothek",
+        "phototextshort": "Fotos",
+        "savebtn": "Speichern",
+        "title": "Strecke speichern",
+        "titleEdit": "Strecke bearbeiten"
+      },
+      "odo": "Zurückgelegte Km",
+      "pausebtn": "Pause",
+      "resumebtn": "Fortsetzen",
+      "stopbtn": "Beenden",
+      "time": "In Bewegung",
+      "title": "Eine Strecke aufzeichnen"
+    },
+    "registeruser": {
+      "cf": "Steuer-ID",
+      "cfextra": "Warum fragen wir nach der Steuer-ID?",
+      "cfph": "XXXXXXXXXXXXXXXX",
+      "cfpopovermessage": "Wenn Sie CAI-Mitglied sind, geben Sie Ihre Steuer-ID während der Registrierung ein. Für Sie ist der Download der Etappen des Sentiero Italia CAI automatisch kostenlos!",
+      "cfpopovertitle": "Warum fragen wir nach der Steuer-ID?",
+      "confirmPassword": "Passwort bestätigen",
+      "confirmPasswordph": "Passwort wiederholen",
+      "email": "E-Mail",
+      "emailph": "beispiel@email.com",
+      "errors": {
+        "form": {
+          "nameRequired": "Es ist erforderlich, einen Namen einzugeben"
+        },
+        "form.cfInvalid": "Die Steuer-ID ist ungültig",
+        "form.confirmPasswordInvalid": "Die Bestätigung stimmt nicht mit dem oben eingegebenen Passwort überein",
+        "form.confirmPasswordRequired": "Es ist erforderlich, das Passwort zu bestätigen",
+        "form.emailInvalid": "E-Mail ist ungültig",
+        "form.emailRequired": "Es ist erforderlich, eine E-Mail einzugeben",
+        "form.passwordRequired": "Es ist erforderlich, ein Passwort einzugeben"
+      },
+      "genericError": "Fehler bei der Benutzerregistrierung",
+      "loading": "Registrierung läuft",
+      "name": "Name",
+      "nameph": "Geben Sie Ihren Namen ein",
+      "password": "Passwort",
+      "passwordph": "Geben Sie Ihr Passwort ein",
+      "privacy1": "Durch Klicken auf \"Registrieren\" akzeptieren Sie unsere ",
+      "privacy2": "und",
+      "privacy3": "",
+      "privacylink1": "Datenschutzrichtlinie",
+      "privacylink2": "Allgemeine Geschäftsbedingungen",
+      "registerbutton": "Registrieren",
+      "title": "Treten Sie der Webmapp-Community bei!"
+    },
+    "route": {
+      "btnFullMapExpand": "Erweitern",
+      "btnFullMapReduce": "Reduzieren",
+      "btndnavigate": "Navigieren",
+      "btndownload": "Herunterladen",
+      "btnfavourite": "Favoriten",
+      "btnshare": "Teilen",
+      "description": {
+        "description": "Beschreibung",
+        "gallery": "Galerie"
+      },
+      "detail": {
+        "from": "Start",
+        "to": "Ziel",
+        "ascent": "Höhenunterschied +",
+        "descent": "Höhenunterschied -",
+        "distance": "Distanz",
+        "duration_forward": "Dauer der Hinreise",
+        "duration_backward": "Dauer der Rückreise",
+        "difficulty": "Schwierigkeit",
+        "ele_from": "Start-Höhe",
+        "ele_max": "Maximale Höhe",
+        "ele_min": "Minimale Höhe",
+        "ele_to": "Ziel-Höhe"
+      },
+      "directions": "Wegbeschreibung erhalten",
+      "download": "Herunterladen",
+      "downloadpanel": {
+        "complete": "Download abgeschlossen",
+        "dontclose": "Schließen Sie die App nicht während der Dateninstallation",
+        "downdata": "Daten werden heruntergeladen",
+        "download": "Herunterladen",
+        "downloadbtn": "Herunterladen",
+        "downloading": "Wird heruntergeladen",
+        "downmap": "Karte wird heruntergeladen",
+        "downmedia": "Medien werden heruntergeladen",
+        "downsetup": "Erstkonfiguration",
+        "gotobtn": "Zu meinen Downloads gehen",
+        "install": "Installation"
+      },
+      "favbtn": {
+        "isFavourite": "Zu Favoriten hinzugefügt!",
+        "isNotFavourite": "Aus Favoriten entfernt!"
+      },
+      "modalconfirm": {
+        "cancel": "Abbrechen",
+        "confirm": "Beenden",
+        "text": "Beenden, ohne den Streckendownload abzuschließen?",
+        "title": "Download unterbrechen?"
+      },
+      "navigate": "Navigieren",
+      "share": "Teilen",
+      "tabdescription": "Beschreibung",
+      "tabdetail": "Details",
+      "tabeat": "Wo essen",
+      "tabhowto": "Wie man hinkommt",
+      "tabviability": "Befahrbarkeit",
+      "tabwalkable": "Zugänglichkeit",
+      "viability": {
+        "info": "Weitere Informationen",
+        "title": "Befahrbarkeit der Strecke"
+      }
+    },
+    "store": {
+      "button1": "1 Einzelmünze",
+      "button100": "Paket mit 100 Münzen",
+      "button20": "Paket mit 20 Münzen",
+      "button50": "Paket mit 50 Münzen",
+      "main": "Webmapp-Münzen",
+      "text": "Sie können eine Einzelmünze kaufen oder zwischen einem oder mehreren Paketen wählen!",
+      "text2": "Münzen dienen zum Herunterladen von Strecken und Offline-Inhalten und zum Zugriff auf viele Vorteile!",
+      "title": "Shop"
+    },
+    "trackdetail": {
+      "avgspeed": "Durchschnittsgeschwindigkeit",
+      "delete": "Aufzeichnung löschen",
+      "details": "Details",
+      "distance": "Zurückgelegte Km",
+      "edit": "Aufzeichnung bearbeiten",
+      "photos": "Fotos",
+      "slope": "Höhenunterschied",
+      "time": "Zeit",
+      "title": "Aufgezeichnete Strecke",
+      "topspeed": "Höchstgeschwindigkeit"
+    },
+    "tracklist": {
+      "noitem": "Derzeit sind keine Strecken aufgezeichnet",
+      "title": "Aufgezeichnete Strecken"
+    },
+    "waypoint": {
+      "here": "Sie sind hier:",
+      "modalsave": {
+        "formdescription": "Beschreibung",
+        "formdescriptionplaceholder": "Wenn Sie möchten, können Sie eine Beschreibung hinzufügen",
+        "formoptional": "Optional",
+        "formphotos": "Fotos des Wegpunkts hinzufügen",
+        "formtitle": "Titel des Wegpunkts",
+        "formtitleerror": "Der Titel des Wegpunkts ist erforderlich",
+        "formtitleplaceholder": "Geben Sie einen Titel ein",
+        "formtype": "Typ des Wegpunkts",
+        "formtypeerror": "Der Typ des Wegpunkts ist erforderlich",
+        "formtypeplaceholder": "Wählen",
+        "photoaction": "Hochladen",
+        "photoactionshort": "Hinzufügen",
+        "photoadvice": "Maximale Größe: 3 Fotos",
+        "photoadviceshort": "(max 3 Fotos)",
+        "phototext": "Fotos aus der Telefonbibliothek",
+        "phototextshort": "Fotos",
+        "save": "Speichern ",
+        "title": "Einen Wegpunkt aufzeichnen"
+      },
+      "save": "Wegpunkt speichern",
+      "title": "Einen Wegpunkt aufzeichnen"
+    },
+    "waypointdetail": {
+      "delete": "Aufzeichnung löschen",
+      "edit": "Aufzeichnung bearbeiten",
+      "title": "Aufgezeichneter Wegpunkt"
+    },
+    "waypointlist": {
+      "noitem": "Derzeit sind keine Wegpunkte aufgezeichnet",
+      "title": "Aufgezeichnete Wegpunkte"
+    },
+    "project": {
+      "title": "Projekt"
+    },
+    "credits": {
+      "title": "Credits",
+      "webmappContent1": "Die App {{appName}} wird von Webmapp entwickelt und gewartet.<br> Webmapp bietet kartografische Dienste im Internet, mobile Apps und gedruckte Karten für Natur- und Abenteuertourismus.<br>Für weitere Informationen besuchen Sie unsere Website ",
+      "webmappContent2": " oder schreiben Sie uns an <a href=\"mailto:info@webmapp.it\">info@webmapp.it</a>",
+      "map": "Karte",
+      "mapContent": "© Webmapp, verteilt unter der Lizenz CC BY-NC-SA",
+      "cartographicData": "Kartografische Daten",
+      "cartographicDataContent": "© OpenStreetMap-Mitwirkende"
+    },
+    "disclaimer": {
+      "title": "Haftungsausschluss",
+      "content": "Wandern in der Natur und allgemein Outdoor-Aktivitäten sind potenziell gefährliche Aktivitäten: Bevor Sie sich auf eine Exkursion begeben, stellen Sie sicher, dass Sie über das Wissen und die Fähigkeiten verfügen, dies zu tun. Wenn Sie sich nicht sicher sind, wenden Sie sich an lokale Experten, die Ihnen helfen, vorschlagen und unterstützen können, Ihre Aktivitäten zu planen und durchzuführen. Die in dieser APP präsentierten Daten können die risikofreie Befahrbarkeit der Strecke nicht vollständig garantieren: Seit der letzten Überprüfung der Strecke können sich Änderungen, auch wesentliche, ergeben haben. Daher ist es unerlässlich, dass diejenigen, die Aktivitäten entwickeln möchten, sorgfältig die Möglichkeit des Fortfahrens auf der Grundlage der in dieser APP enthaltenen Vorschläge und Ratschläge, ihrer Erfahrung, der Wetterbedingungen (auch der vorherigen Tage) und einer vor Ort durchgeführten Bewertung zu Beginn der Aktivität bewerten. Die Firma Webmapp S.r.l. bietet keine Garantie für die Sicherheit der beschriebenen Orte und übernimmt keine Verantwortung für mögliche Schäden, die durch die Durchführung der beschriebenen Aktivitäten entstehen."
+    }
+  },
+  "services": {
+    "geolocation": {
+      "notification": {
+        "text": {
+          "newTrackRecord": "Tippen Sie auf die Benachrichtigung, um die App zu öffnen"
+        },
+        "title": {
+          "newTrackRecord": "Aufnahme läuft"
+        }
+      }
+    },
+    "share": {
+      "dialogTitle": "Mit Ihren Freunden teilen",
+      "text": "Hier ist eine interessante Strecke von Webmapp",
+      "title": "Haben Sie diese Strecke gesehen?",
+      "url": "www.webmapp.it"
+    }
+  },
+  "tabs": {
+    "favourites": "Favoriten",
+    "home": "Home",
+    "map": "Karte",
+    "profile": "Profil"
+  },
+  "no-tracks": "Sie haben noch keine Strecke heruntergeladen",
+  "hiking": "Wandern",
+  "skitouring": "Skitour",
+  "walking": "Spazieren",
+  "running": "Laufen",
+  "asphalt": "Asphalt",
+  "bitumenduro": "Bitumenduro",
+  "onoff": "On/Off",
+  "real-dirt": "Echter Schmutz",
+  "bar": "Bar",
+  "cycling": "Radfahren",
+  "poi_type": "Interessenspunkt",
+  "where": "Orte",
+  "I tuoi dati": "Ihre Daten",
+  "Scarica il tracciato GPX": "GPX-Strecke herunterladen",
+  "Scarica il tracciato KML": "KML-Strecke herunterladen",
+  "Scarica il tracciato GEOJSON": "GEOJSON-Strecke herunterladen",
+  "Elimina account": "Konto löschen",
+  "Vuoi veramente eliminare il tuo account? È obbligatorio scrivere 'elimina account' per procedere.": "Möchten Sie Ihr Konto wirklich löschen? Es ist erforderlich, 'Konto löschen' zu schreiben, um fortzufahren.",
+  "Digita 'elimina account'": "Geben Sie 'Konto löschen' ein",
+  "La conferma non corrisponde. È necessario scrivere 'elimina account' per procedere.": "Die Bestätigung stimmt nicht überein. Es ist erforderlich, 'Konto löschen' zu schreiben, um fortzufahren.",
+  "Azione irreversibile": "Unumkehrbare Aktion",
+  "Attenzione": "Achtung",
+  "Annulla": "Abbrechen",
+  "Conferma": "Bestätigen",
+  "Link utili": "Nützliche Links",
+  "Per registrare tracce e poi correttamente, abilita l'autorizzazione alla posizione nelle impostazioni": "Um Strecken korrekt aufzuzeichnen und anzuzeigen, aktivieren Sie die Standortberechtigung in den Einstellungen",
+  "Apri impostazioni App": "App-Einstellungen öffnen"
+}

--- a/core/src/assets/i18n/es.json
+++ b/core/src/assets/i18n/es.json
@@ -1,0 +1,602 @@
+{
+  "activities": {
+    "cycling": "Ciclismo",
+    "hiking": "Senderismo",
+    "running": "Correr",
+    "skitouring": "Esquí de travesía",
+    "walking": "Caminar",
+    "asphalt": "Asfalto",
+    "bitumenduro": "Bitumenduro",
+    "onoff": "On/Off",
+    "real-dirt": "Tierra real",
+    "bar": "Bar"
+  },
+  "sidemenu": {
+    "project": "Proyecto",
+    "offline": "Desconectado",
+    "settings": "Configuraciones",
+    "credits": "Créditos",
+    "disclaimer": "Aviso legal"
+  },
+  "components": {
+    "cardtrack": {
+      "delete": "Eliminar",
+      "remove": "Quitar"
+    },
+    "map": {
+      "btnrec": {
+        "slide": "Deslizar para grabar"
+      },
+      "register": {
+        "cancel": "Cancelar",
+        "photo": "Foto",
+        "title": "Registrar",
+        "track": "Ruta",
+        "vocal": "Nota de voz",
+        "waypoint": "Punto de referencia"
+      }
+    },
+    "searchbar": {
+      "filters": "Filtrar por",
+      "nofilters": "Ningún filtro coincide con la búsqueda realizada",
+      "noplaces": "Ningún lugar coincide con la búsqueda realizada",
+      "notracks": "Ninguna ruta coincide con la búsqueda realizada",
+      "placeholder": "buscar",
+      "places": "Lugares",
+      "tracks": "Rutas"
+    },
+    "slopechart": {
+      "slope": {
+        "label": "pendiente"
+      },
+      "surfaces": {
+        "asphalt": {
+          "label": "asfalto"
+        },
+        "concrete": {
+          "label": "hormigón"
+        },
+        "dirt": {
+          "label": "tierra"
+        },
+        "grass": {
+          "label": "césped"
+        },
+        "gravel": {
+          "label": "grava"
+        },
+        "paved": {
+          "label": "pavimentado"
+        },
+        "sand": {
+          "label": "arena"
+        }
+      }
+    }
+  },
+  "generic": {
+    "cancel": "cancelar",
+    "confirm": "confirmar",
+    "delete": "eliminar",
+    "error": "Ocurrió un error. Inténtalo de nuevo más tarde",
+    "hour": "hora",
+    "minute": "min",
+    "ok": "ok",
+    "retry": "intentar de nuevo",
+    "warning": "Atención"
+  },
+  "modals": {
+    "coin": {
+      "buttonall": "Ver todos los paquetes de monedas",
+      "buttonone": "Comprar 1 Moneda / 1€",
+      "defaultmessage": "Compra monedas para descargar contenido offline",
+      "info1": "Puedes comprar una sola ruta",
+      "info2": "Todo está disponible incluso sin cobertura",
+      "info3": "Recibe notificaciones de proximidad",
+      "subinfo1": "Compra una sola moneda por 1€",
+      "subinfo2": "Navegación precisa incluso cuando estás desconectado",
+      "subinfo3": "Te notificamos cerca de puntos de interés en la ruta"
+    },
+    "giftcoin": {
+      "button": "Comienza a explorar",
+      "info": "¡Recibes inmediatamente 2 monedas webmapp de regalo para descargar contenido offline!",
+      "title": "¡Bienvenido a webmapp!"
+    },
+    "login": {
+      "email": "Correo electrónico",
+      "errors": {
+        "401": "Las credenciales que ingresaste no son correctas. Verifica el correo electrónico y la contraseña e inténtalo de nuevo",
+        "form": {
+          "emailInvalid": "Has ingresado un correo electrónico no válido",
+          "emailRequired": "El correo electrónico es obligatorio",
+          "passwordRequired": "La contraseña es obligatoria"
+        },
+        "generic": "¡Ups! Algo salió mal. Espera unos minutos e inténtalo de nuevo."
+      },
+      "forgotPassword": "¿Olvidaste tu contraseña?",
+      "login": "Iniciar sesión",
+      "message": "Inicia sesión con tus credenciales para continuar.",
+      "password": "Contraseña",
+      "rememberLogin": "Recordar credenciales",
+      "title": "Iniciar sesión",
+      "welcome": "¡Bienvenido de nuevo!"
+    },
+    "photo": {
+      "next": "Siguiente",
+      "popover": {
+        "cancel": "Cancelar",
+        "library": "De la biblioteca",
+        "shot": "Tomar una foto",
+        "title": "Fuente de la imagen"
+      },
+      "save": {
+        "addphoto": "Agregar foto",
+        "formphototitle": "Título ",
+        "formtitle": "Dale un título a tus fotos",
+        "modalconfirm": {
+          "cancel": "Cancelar",
+          "confirm": "Sí, eliminar",
+          "text": "Si lo eliminas, no se añadirá a este registro",
+          "title": "¿Estás seguro de que deseas eliminar esta foto del registro?"
+        },
+        "placeholder": "Aquí puedes ingresar un título",
+        "savebtn": "Guardar",
+        "title": "Registrar foto"
+      },
+      "single": {
+        "formphototitle": "Título",
+        "placeholder": "Aquí puedes ingresar un título",
+        "savebtn": "Hecho",
+        "title": "Modificar foto"
+      }
+    },
+    "settings": {
+      "alert": {
+        "logout": "¿Estás seguro de que deseas cerrar sesión en tu cuenta?"
+      },
+      "logout": "Cerrar sesión",
+      "title": "Configuraciones",
+      "version": "Versión"
+    },
+    "storesuccess": {
+      "back": "Volver a la búsqueda",
+      "buttondownload": "Descargar ahora",
+      "continue": "¿Deseas usar tu moneda inmediatamente para descargar ",
+      "continue2": "?",
+      "info": "¡Puedes verificar el saldo de tus monedas directamente en tu área personal!",
+      "or": "O",
+      "title": "¡Gracias por comprar tu primera moneda!"
+    },
+    "success": {
+      "photos": {
+        "text": "Tus fotos se han guardado con éxito. Puedes verlas accediendo a tu perfil.",
+        "title": "¡Fotos registradas con éxito!"
+      },
+      "return": "Volver a explorar",
+      "track": {
+        "avgspeed": "Velocidad media",
+        "odo": "Km recorridos",
+        "slope": "Diferencia de altitud",
+        "text": "Las rutas se han guardado con éxito. Puedes verlas accediendo a tu perfil.",
+        "time": "Tiempo",
+        "title": "¡Actividad registrada con éxito!",
+        "topspeed": "Velocidad máxima"
+      },
+      "waypoint": {
+        "text": "Has guardado con éxito tu punto de referencia. Puedes verlo accediendo a tu perfil.",
+        "title": "¡Punto de referencia registrado con éxito!"
+      }
+    }
+  },
+  "pages": {
+    "downloadlist": {
+      "cancel": "Cancelar",
+      "deleteselected": "Eliminar seleccionados",
+      "nodata": "Aún no has descargado ninguna ruta",
+      "nodata2": "¡Con contenido para uso offline, navegas con tranquilidad incluso sin conexión!",
+      "nodatabtn": "Explorar",
+      "select": "Seleccionar",
+      "title": "Descargas"
+    },
+    "favourites": {
+      "nodata": "No hay rutas favoritas, haz clic en el icono de corazón de una ruta para añadirla a esta lista",
+      "title": "Favoritos"
+    },
+    "home": {
+      "button": "Elige un punto de partida",
+      "closerTracks": "Rutas cercanas",
+      "intro": "Planificamos juntos tu próxima aventura",
+      "mostViewedTracks": "Rutas más vistas",
+      "nocloserTracks": "Parece que no hay rutas cerca de tu ubicación actual",
+      "welcome": "¡Bienvenido!"
+    },
+    "itinerary": {
+      "btnFullMapExpand": "Expandir",
+      "btnFullMapReduce": "Reducir",
+      "btndnavigate": "Navegar",
+      "btndownload": "Descargar",
+      "btnfavourite": "Favoritos",
+      "btnshare": "Compartir",
+      "description": {
+        "description": "Descripción",
+        "gallery": "Galería"
+      },
+      "detail": {
+        "ascent": "Diferencia de altitud +",
+        "descent": "Diferencia de altitud -",
+        "distance": "Distancia",
+        "ele_from": "Altitud de partida",
+        "ele_max": "Altitud máxima",
+        "ele_min": "Altitud mínima",
+        "ele_to": "Altitud de llegada"
+      },
+      "directions": "Obtener direcciones",
+      "download": "Descargar",
+      "downloadpanel": {
+        "complete": "Descarga completada",
+        "dontclose": "No cierres la aplicación durante la fase de instalación de datos",
+        "downdata": "Descargando datos",
+        "download": "Descargar",
+        "downloadbtn": "Descargar",
+        "downloading": "Descargando",
+        "downmap": "Descargando mapa",
+        "downmedia": "Descargando medios",
+        "downsetup": "Configuración inicial",
+        "gotobtn": "Ir a mis descargas",
+        "install": "Instalación"
+      },
+      "favbtn": {
+        "isFavourite": "¡Añadido a favoritos!",
+        "isNotFavourite": "¡Eliminado de favoritos!"
+      },
+      "modalconfirm": {
+        "cancel": "Cancelar",
+        "confirm": "Salir",
+        "text": "¿Salir sin completar la descarga de la ruta?",
+        "title": "¿Interrumpir la descarga?"
+      },
+      "modalNotImpemented": {
+        "text": "Próximamente",
+        "title": "Actualmente no disponible",
+        "confirm": "ok"
+      },
+      "navigate": "Navegar",
+      "share": "Compartir",
+      "tabdescription": "Descripción",
+      "tabdetail": "Detalles",
+      "tabeat": "Dónde comer",
+      "tabhowto": "Cómo llegar",
+      "tabviability": "Viabilidad",
+      "tabwalkable": "Accesibilidad",
+      "viability": {
+        "info": "Otras informaciones",
+        "title": "Viabilidad de la ruta"
+      }
+    },
+    "map": {
+      "loading": "buscando...",
+      "recordingbtn": "Grabando",
+      "searchherebtn": "Buscar en esta área"
+    },
+    "photodetail": {
+      "delete": "Eliminar registro",
+      "edit": "Modificar registro",
+      "title": "Foto registrada"
+    },
+    "photolist": {
+      "noitem": "Actualmente no hay fotos registradas",
+      "title": "Fotos registradas"
+    },
+    "profile": {
+      "data": {
+        "data": "Uso de datos",
+        "downloads": "Descargas",
+        "tracks": "Rutas descargadas"
+      },
+      "loggedOut": {
+        "login": "Iniciar sesión",
+        "signup": "Registrarse",
+        "slides": {
+          "0": "Inicia sesión y descarga tus rutas favoritas",
+          "1": "También puedes compartirlas con tus amigos de viaje"
+        }
+      },
+      "records": {
+        "photos": "Fotos",
+        "title": "Registros",
+        "tracks": "Rutas",
+        "vocals": "Notas de voz",
+        "waypoints": "Puntos de referencia"
+      },
+      "title": "Perfil",
+      "lang": "idioma",
+      "langPlaceholder": "elegir",
+      "projectlink": "Proyecto",
+      "disclaimerlink": "Aviso legal",
+      "creditslink": "Créditos",
+      "privacylink": "Privacidad"
+    },
+    "register": {
+      "averagespeed": "Velocidad media",
+      "backgroundbtn": "Grabar en segundo plano",
+      "currentspeed": "Velocidad actual",
+      "modalconfirm": {
+        "cancel": "Cancelar",
+        "confirm": "Confirmar",
+        "text": "Una vez confirmado, no podrás reiniciar esta navegación",
+        "title": "¿Confirmas que deseas finalizar la grabación?"
+      },
+      "modalexit": {
+        "cancel": "Cancelar",
+        "confirm": "Eliminar",
+        "text": "Al finalizar la acción, la ruta se eliminará de tu perfil y de Webmapp. La operación no se puede deshacer.",
+        "title": "¿Eliminar permanentemente?"
+      },
+      "modalphotos": {
+        "deselectall": "Deseleccionar todo",
+        "noimages": "No hay imágenes capturadas durante el registro de la ruta",
+        "savebtn": "Cargar",
+        "selectall": "Seleccionar todo",
+        "title": "Cargar fotos"
+      },
+      "modalsave": {
+        "closemodal": {
+          "back": "Volver al registro",
+          "cancel": "Cancelar",
+          "delete": "Eliminar registro"
+        },
+        "deletebtn": "SALIR SIN GUARDAR",
+        "formactivity": "Tipo de actividad",
+        "formactivityerror": "El tipo de actividad es un campo obligatorio",
+        "formactivityplaceholder": "Elegir",
+        "formdescription": "Descripción",
+        "formdescriptionplaceholder": "Si lo deseas, puedes añadir una descripción",
+        "formphotos": "Añadir fotos capturadas durante la ruta",
+        "formtitle": "Título de la ruta",
+        "formtitleerror": "El campo de título es obligatorio",
+        "formtitleplaceholder": "Introduce un título",
+        "photoaction": "Cargar",
+        "photoactionshort": "Añadir",
+        "photoadvice": "Tamaño máximo: 3 fotos",
+        "photoadviceshort": "(máx 3 fotos)",
+        "phototext": "fotos de la galería del teléfono",
+        "phototextshort": "Fotos",
+        "savebtn": "Guardar",
+        "title": "Guardar ruta",
+        "titleEdit": "Modificar ruta"
+      },
+      "odo": "Km recorridos",
+      "pausebtn": "Pausar",
+      "resumebtn": "Continuar",
+      "stopbtn": "Finalizar",
+      "time": "En movimiento",
+      "title": "Registrar una ruta"
+    },
+    "registeruser": {
+      "cf": "Código Fiscal",
+      "cfextra": "¿Por qué pedimos el CF?",
+      "cfph": "XXXXXXXXXXXXXXXX",
+      "cfpopovermessage": "Si eres Miembro CAI, ingresa tu CF durante el registro. Para ti, la descarga de las etapas del Sentiero Italia CAI será automáticamente gratuita.",
+      "cfpopovertitle": "¿Por qué pedimos el Código Fiscal?",
+      "confirmPassword": "Confirmar contraseña",
+      "confirmPasswordph": "Repite la contraseña",
+      "email": "Correo electrónico",
+      "emailph": "ejemplo@email.com",
+      "errors": {
+        "form": {
+          "nameRequired": "Es necesario ingresar un nombre"
+        },
+        "form.cfInvalid": "El código fiscal no es válido",
+        "form.confirmPasswordInvalid": "La confirmación no coincide con la contraseña ingresada arriba",
+        "form.confirmPasswordRequired": "Es necesario confirmar la contraseña",
+        "form.emailInvalid": "El correo electrónico no es válido",
+        "form.emailRequired": "Es necesario ingresar un correo electrónico",
+        "form.passwordRequired": "Es necesario ingresar una contraseña"
+      },
+      "genericError": "Error al registrar el usuario",
+      "loading": "Registro en proceso",
+      "name": "Nombre",
+      "nameph": "ingresa tu nombre",
+      "password": "Contraseña",
+      "passwordph": "ingresa tu contraseña",
+      "privacy1": "Al hacer clic en \"Registrarse\" aceptas nuestra ",
+      "privacy2": "y",
+      "privacy3": "",
+      "privacylink1": "Política de Privacidad",
+      "privacylink2": "Términos y condiciones",
+      "registerbutton": "Registrarse",
+      "title": "¡Únete a la comunidad de webmapp!"
+    },
+    "route": {
+      "btnFullMapExpand": "Expandir",
+      "btnFullMapReduce": "Reducir",
+      "btndnavigate": "Navegar",
+      "btndownload": "Descargar",
+      "btnfavourite": "Favoritos",
+      "btnshare": "Compartir",
+      "description": {
+        "description": "Descripción",
+        "gallery": "Galería"
+      },
+      "detail": {
+        "from": "Salida",
+        "to": "Llegada",
+        "ascent": "Diferencia de altitud +",
+        "descent": "Diferencia de altitud -",
+        "distance": "Distancia",
+        "duration_forward": "duración de ida",
+        "duration_backward": "duración de vuelta",
+        "difficulty": "Dificultad",
+        "ele_from": "Altitud de salida",
+        "ele_max": "Altitud máxima",
+        "ele_min": "Altitud mínima",
+        "ele_to": "Altitud de llegada"
+      },
+      "directions": "Obtener direcciones",
+      "download": "Descargar",
+      "downloadpanel": {
+        "complete": "Descarga completada",
+        "dontclose": "No cierres la aplicación durante la fase de instalación de datos",
+        "downdata": "Descargando datos",
+        "download": "Descargar",
+        "downloadbtn": "Descargar",
+        "downloading": "Descargando",
+        "downmap": "Descargando mapa",
+        "downmedia": "Descargando medios",
+        "downsetup": "Configuración inicial",
+        "gotobtn": "Ir a mis descargas",
+        "install": "Instalación"
+      },
+      "favbtn": {
+        "isFavourite": "¡Añadido a favoritos!",
+        "isNotFavourite": "¡Eliminado de favoritos!"
+      },
+      "modalconfirm": {
+        "cancel": "Cancelar",
+        "confirm": "Salir",
+        "text": "¿Salir sin completar la descarga de la ruta?",
+        "title": "¿Interrumpir la descarga?"
+      },
+      "navigate": "Navegar",
+      "share": "Compartir",
+      "tabdescription": "Descripción",
+      "tabdetail": "Detalles",
+      "tabeat": "Dónde comer",
+      "tabhowto": "Cómo llegar",
+      "tabviability": "Viabilidad",
+      "tabwalkable": "Accesibilidad",
+      "viability": {
+        "info": "Otras informaciones",
+        "title": "Viabilidad de la ruta"
+      }
+    },
+    "store": {
+      "button1": "1 Moneda Única",
+      "button100": "Paquete de 100 monedas",
+      "button20": "Paquete de 20 Monedas",
+      "button50": "Paquete de 50 monedas",
+      "main": "Monedas Webmapp",
+      "text": "¡Puedes comprar una Moneda única, o elegir entre uno o más paquetes!",
+      "text2": "¡Las monedas sirven para descargar rutas y contenido offline, y para acceder a muchos beneficios!",
+      "title": "Tienda"
+    },
+    "trackdetail": {
+      "avgspeed": "Velocidad media",
+      "delete": "Eliminar registro",
+      "details": "Detalles",
+      "distance": "Km recorridos",
+      "edit": "Modificar registro",
+      "photos": "Fotos",
+      "slope": "Diferencia de altitud",
+      "time": "Tiempo",
+      "title": "Ruta registrada",
+      "topspeed": "Velocidad máxima"
+    },
+    "tracklist": {
+      "noitem": "Actualmente no hay rutas registradas",
+      "title": "Rutas registradas"
+    },
+    "waypoint": {
+      "here": "Estás aquí:",
+      "modalsave": {
+        "formdescription": "Descripción",
+        "formdescriptionplaceholder": "Si lo deseas, puedes añadir una descripción",
+        "formoptional": "Opcional",
+        "formphotos": "Añadir fotos del Punto de Referencia",
+        "formtitle": "Título del punto de referencia",
+        "formtitleerror": "El título del punto de referencia es obligatorio",
+        "formtitleplaceholder": "Introduce un título",
+        "formtype": "Tipo de Punto de Referencia",
+        "formtypeerror": "El tipo de punto de referencia es obligatorio",
+        "formtypeplaceholder": "Elegir",
+        "photoaction": "Cargar",
+        "photoactionshort": "Añadir",
+        "photoadvice": "Tamaño máximo: 3 fotos",
+        "photoadviceshort": "(máx 3 fotos)",
+        "phototext": "fotos de la galería del teléfono",
+        "phototextshort": "Fotos",
+        "save": "Guardar ",
+        "title": "Registrar un punto de referencia"
+      },
+      "save": "Guardar punto de referencia",
+      "title": "Registrar un punto de referencia"
+    },
+    "waypointdetail": {
+      "delete": "Eliminar registro",
+      "edit": "Modificar registro",
+      "title": "Punto de referencia registrado"
+    },
+    "waypointlist": {
+      "noitem": "Actualmente no hay puntos de referencia registrados",
+      "title": "Puntos de referencia registrados"
+    },
+    "project": {
+      "title": "Proyecto"
+    },
+    "credits": {
+      "title": "Créditos",
+      "webmappContent1": "La aplicación {{appName}} es desarrollada y mantenida por Webmapp.<br> Webmapp realiza servicios cartográficos en internet, aplicaciones móviles y cartografía impresa para Turismo de Naturaleza & Aventura.<br>Para más información, visita nuestro sitio web ",
+      "webmappContent2": " o escríbenos a <a href=\"mailto:info@webmapp.it\">info@webmapp.it</a>",
+      "map": "Mapa",
+      "mapContent": "© Webmapp, distribuido bajo licencia CC BY-NC-SA",
+      "cartographicData": "Datos cartográficos",
+      "cartographicDataContent": "© Contribuidores de OpenStreetMap"
+    },
+    "disclaimer": {
+      "title": "Aviso legal",
+      "content": "Caminar en la naturaleza y, en general, las actividades al aire libre, son actividades potencialmente peligrosas: antes de partir para una excursión, asegúrate de tener el conocimiento y las habilidades para hacerlo. Si no estás seguro, dirígete a expertos locales que puedan ayudarte, sugerir y apoyar en la planificación y desarrollo de tus actividades. Los datos presentados en esta APLICACIÓN no pueden garantizar completamente la viabilidad sin riesgos de la ruta: pueden haber ocurrido cambios, incluso significativos, desde la última verificación de la ruta. Por lo tanto, es esencial que aquellos que planean desarrollar actividades evalúen cuidadosamente la posibilidad de continuar basándose en las sugerencias y consejos contenidos en esta APLICACIÓN, basándose en su experiencia, las condiciones meteorológicas (incluso de los días anteriores) y una evaluación realizada en el terreno al inicio del desarrollo de la actividad. La empresa Webmapp S.r.l. no ofrece garantías para la seguridad de los lugares descritos y no asume ninguna responsabilidad por posibles daños causados por el desarrollo de las actividades descritas."
+    }
+  },
+  "services": {
+    "geolocation": {
+      "notification": {
+        "text": {
+          "newTrackRecord": "Toca la notificación para abrir la aplicación"
+        },
+        "title": {
+          "newTrackRecord": "Grabación en proceso"
+        }
+      }
+    },
+    "share": {
+      "dialogTitle": "Compartir con tus amigos",
+      "text": "Aquí hay una ruta interesante de webmapp",
+      "title": "¿Has visto esta ruta?",
+      "url": "www.webmapp.it"
+    }
+  },
+  "tabs": {
+    "favourites": "favoritos",
+    "home": "home",
+    "map": "mapa",
+    "profile": "perfil"
+  },
+  "no-tracks": "Aún no has descargado ninguna ruta",
+  "hiking": "Senderismo",
+  "skitouring": "Esquí de travesía",
+  "walking": "Caminar",
+  "running": "Correr",
+  "asphalt": "Asfalto",
+  "bitumenduro": "Bitumenduro",
+  "onoff": "On/Off",
+  "real-dirt": "Tierra real",
+  "bar": "Bar",
+  "cycling": "Ciclismo",
+  "poi_type": "punto de interés",
+  "where": "lugares",
+  "I tuoi dati": "Tus datos",
+  "Scarica il tracciato GPX": "Descargar la ruta GPX",
+  "Scarica il tracciato KML": "Descargar la ruta KML",
+  "Scarica il tracciato GEOJSON": "Descargar la ruta GEOJSON",
+  "Elimina account": "Eliminar cuenta",
+  "Vuoi veramente eliminare il tuo account? È obbligatorio scrivere 'elimina account' per procedere.": "¿Realmente deseas eliminar tu cuenta? Es obligatorio escribir 'eliminar cuenta' para proceder.",
+  "Digita 'elimina account'": "Escribe 'eliminar cuenta'",
+  "La conferma non corrisponde. È necessario scrivere 'elimina account' per procedere.": "La confirmación no coincide. Es necesario escribir 'eliminar cuenta' para proceder.",
+  "Azione irreversibile": "Acción irreversible",
+  "Attenzione": "Atención",
+  "Annulla": "Cancelar",
+  "Conferma": "Confirmar",
+  "Link utili": "Enlaces útiles",
+  "Per registrare tracce e poi correttamente, abilita l'autorizzazione alla posizione nelle impostazioni": "Para registrar rutas y mostrarlas correctamente, activa el permiso de ubicación en configuraciones",
+  "Apri impostazioni App": "Abrir configuraciones de la aplicación"
+}

--- a/core/src/assets/i18n/pr.json
+++ b/core/src/assets/i18n/pr.json
@@ -1,0 +1,602 @@
+{
+  "activities": {
+    "cycling": "Ciclismo",
+    "hiking": "Caminhada",
+    "running": "Corrida",
+    "skitouring": "Esqui",
+    "walking": "Caminhada",
+    "asphalt": "Asfalto",
+    "bitumenduro": "Bitumenduro",
+    "onoff": "On/Off",
+    "real-dirt": "Terra real",
+    "bar": "Bar"
+  },
+  "sidemenu": {
+    "project": "Projeto",
+    "offline": "Offline",
+    "settings": "Configurações",
+    "credits": "Créditos",
+    "disclaimer": "Aviso legal"
+  },
+  "components": {
+    "cardtrack": {
+      "delete": "Excluir",
+      "remove": "Remover"
+    },
+    "map": {
+      "btnrec": {
+        "slide": "Deslize para gravar"
+      },
+      "register": {
+        "cancel": "Cancelar",
+        "photo": "Foto",
+        "title": "Registrar",
+        "track": "Rota",
+        "vocal": "Nota de voz",
+        "waypoint": "Ponto de referência"
+      }
+    },
+    "searchbar": {
+      "filters": "Filtrar por",
+      "nofilters": "Nenhum filtro corresponde à pesquisa realizada",
+      "noplaces": "Nenhum lugar corresponde à pesquisa realizada",
+      "notracks": "Nenhuma rota corresponde à pesquisa realizada",
+      "placeholder": "pesquisar",
+      "places": "Lugares",
+      "tracks": "Rotas"
+    },
+    "slopechart": {
+      "slope": {
+        "label": "inclinação"
+      },
+      "surfaces": {
+        "asphalt": {
+          "label": "asfalto"
+        },
+        "concrete": {
+          "label": "concreto"
+        },
+        "dirt": {
+          "label": "terra"
+        },
+        "grass": {
+          "label": "grama"
+        },
+        "gravel": {
+          "label": "cascalho"
+        },
+        "paved": {
+          "label": "pavimentado"
+        },
+        "sand": {
+          "label": "areia"
+        }
+      }
+    }
+  },
+  "generic": {
+    "cancel": "cancelar",
+    "confirm": "confirmar",
+    "delete": "excluir",
+    "error": "Ocorreu um erro. Tente novamente mais tarde",
+    "hour": "hora",
+    "minute": "min",
+    "ok": "ok",
+    "retry": "tentar novamente",
+    "warning": "Atenção"
+  },
+  "modals": {
+    "coin": {
+      "buttonall": "Ver todos os pacotes de moedas",
+      "buttonone": "Comprar 1 Moeda / 1€",
+      "defaultmessage": "Compre moedas para baixar conteúdo offline",
+      "info1": "Você pode comprar uma única rota",
+      "info2": "Tenha tudo disponível mesmo sem cobertura",
+      "info3": "Receba notificações de proximidade",
+      "subinfo1": "Compre uma única moeda por 1€",
+      "subinfo2": "Navegação precisa mesmo quando offline",
+      "subinfo3": "Notificamos você na proximidade de pontos de interesse na rota"
+    },
+    "giftcoin": {
+      "button": "Comece a explorar",
+      "info": "Você ganha imediatamente 2 moedas webmapp de presente para baixar conteúdo offline!",
+      "title": "Bem-vindo ao webmapp!"
+    },
+    "login": {
+      "email": "E-mail",
+      "errors": {
+        "401": "As credenciais que você inseriu não estão corretas. Verifique o e-mail e a senha e tente novamente",
+        "form": {
+          "emailInvalid": "Você inseriu um e-mail inválido",
+          "emailRequired": "E-mail é obrigatório",
+          "passwordRequired": "Senha é obrigatória"
+        },
+        "generic": "Oops! Algo deu errado! Aguarde alguns minutos e tente novamente."
+      },
+      "forgotPassword": "Esqueceu a senha?",
+      "login": "Entrar",
+      "message": "Entre com suas credenciais para continuar.",
+      "password": "Senha",
+      "rememberLogin": "Lembrar credenciais",
+      "title": "Entrar",
+      "welcome": "Bem-vindo de volta!"
+    },
+    "photo": {
+      "next": "Próximo",
+      "popover": {
+        "cancel": "Cancelar",
+        "library": "Da biblioteca",
+        "shot": "Tirar uma foto",
+        "title": "Fonte da imagem"
+      },
+      "save": {
+        "addphoto": "Adicionar foto",
+        "formphototitle": "Título ",
+        "formtitle": "Dê um título às suas fotos",
+        "modalconfirm": {
+          "cancel": "Cancelar",
+          "confirm": "Sim, excluir",
+          "text": "Se você excluir, não será adicionado a este registro",
+          "title": "Tem certeza de que deseja excluir esta foto do registro?"
+        },
+        "placeholder": "Aqui você pode inserir um título",
+        "savebtn": "Salvar",
+        "title": "Registrar foto"
+      },
+      "single": {
+        "formphototitle": "Título",
+        "placeholder": "Aqui você pode inserir um título",
+        "savebtn": "Feito",
+        "title": "Modificar foto"
+      }
+    },
+    "settings": {
+      "alert": {
+        "logout": "Tem certeza de que deseja sair da sua conta?"
+      },
+      "logout": "Sair",
+      "title": "Configurações",
+      "version": "Versão"
+    },
+    "storesuccess": {
+      "back": "Voltar para a pesquisa",
+      "buttondownload": "Baixar agora",
+      "continue": "Deseja usar sua moeda imediatamente para baixar ",
+      "continue2": "?",
+      "info": "Você pode verificar o saldo de suas moedas diretamente na sua área pessoal!",
+      "or": "Ou",
+      "title": "Obrigado por comprar sua primeira moeda!"
+    },
+    "success": {
+      "photos": {
+        "text": "Suas fotos foram salvas com sucesso. Você pode visualizá-las acessando seu perfil.",
+        "title": "Fotos registradas com sucesso!"
+      },
+      "return": "Voltar para explorar",
+      "track": {
+        "avgspeed": "Velocidade média",
+        "odo": "Km percorridos",
+        "slope": "Diferença de altitude",
+        "text": "As rotas foram salvas com sucesso. Você pode visualizá-las acessando seu perfil.",
+        "time": "Tempo",
+        "title": "Atividade registrada com sucesso!",
+        "topspeed": "Velocidade máxima"
+      },
+      "waypoint": {
+        "text": "Você salvou com sucesso seu ponto de referência. Você pode visualizá-lo acessando seu perfil.",
+        "title": "Ponto de referência registrado com sucesso!"
+      }
+    }
+  },
+  "pages": {
+    "downloadlist": {
+      "cancel": "Cancelar",
+      "deleteselected": "Excluir selecionados",
+      "nodata": "Você ainda não baixou nenhuma rota",
+      "nodata2": "Com conteúdos para uso offline, você navega com tranquilidade mesmo sem conexão!",
+      "nodatabtn": "Explorar",
+      "select": "Selecionar",
+      "title": "Downloads"
+    },
+    "favourites": {
+      "nodata": "Não há rotas favoritas, clique no ícone de coração de uma rota para adicioná-la a esta lista",
+      "title": "Favoritos"
+    },
+    "home": {
+      "button": "Escolha um ponto de partida",
+      "closerTracks": "Rotas próximas",
+      "intro": "Planejamos juntos sua próxima aventura",
+      "mostViewedTracks": "Rotas mais visualizadas",
+      "nocloserTracks": "Parece que não há rotas próximas à localização atual",
+      "welcome": "Bem-vindo!"
+    },
+    "itinerary": {
+      "btnFullMapExpand": "Expandir",
+      "btnFullMapReduce": "Reduzir",
+      "btndnavigate": "Navegar",
+      "btndownload": "Baixar",
+      "btnfavourite": "Favoritos",
+      "btnshare": "Compartilhar",
+      "description": {
+        "description": "Descrição",
+        "gallery": "Galeria"
+      },
+      "detail": {
+        "ascent": "Diferença de altitude +",
+        "descent": "Diferença de altitude -",
+        "distance": "Distância",
+        "ele_from": "Altitude de partida",
+        "ele_max": "Altitude máxima",
+        "ele_min": "Altitude mínima",
+        "ele_to": "Altitude de chegada"
+      },
+      "directions": "Obter direções",
+      "download": "Baixar",
+      "downloadpanel": {
+        "complete": "Download concluído",
+        "dontclose": "Não feche o aplicativo durante a fase de instalação dos dados",
+        "downdata": "Baixando dados",
+        "download": "Baixar",
+        "downloadbtn": "Baixar",
+        "downloading": "Baixando",
+        "downmap": "Baixando mapa",
+        "downmedia": "Baixando mídias",
+        "downsetup": "Configuração inicial",
+        "gotobtn": "Ir para meus downloads",
+        "install": "Instalação"
+      },
+      "favbtn": {
+        "isFavourite": "Adicionado aos favoritos!",
+        "isNotFavourite": "Removido dos favoritos!"
+      },
+      "modalconfirm": {
+        "cancel": "Cancelar",
+        "confirm": "Sair",
+        "text": "Sair sem concluir o download da rota?",
+        "title": "Interromper download?"
+      },
+      "modalNotImpemented": {
+        "text": "Em breve",
+        "title": "Atualmente não disponível",
+        "confirm": "ok"
+      },
+      "navigate": "Navegar",
+      "share": "Compartilhar",
+      "tabdescription": "Descrição",
+      "tabdetail": "Detalhes",
+      "tabeat": "Onde comer",
+      "tabhowto": "Como chegar",
+      "tabviability": "Viabilidade",
+      "tabwalkable": "Acessibilidade",
+      "viability": {
+        "info": "Outras informações",
+        "title": "Viabilidade da rota"
+      }
+    },
+    "map": {
+      "loading": "procurando...",
+      "recordingbtn": "Gravando",
+      "searchherebtn": "Pesquisar nesta área"
+    },
+    "photodetail": {
+      "delete": "Excluir registro",
+      "edit": "Modificar registro",
+      "title": "Foto registrada"
+    },
+    "photolist": {
+      "noitem": "Atualmente não há fotos registradas",
+      "title": "Fotos registradas"
+    },
+    "profile": {
+      "data": {
+        "data": "Uso de dados",
+        "downloads": "Downloads",
+        "tracks": "Rotas baixadas"
+      },
+      "loggedOut": {
+        "login": "Entrar",
+        "signup": "Registrar-se",
+        "slides": {
+          "0": "Entre e baixe suas rotas favoritas",
+          "1": "Você também pode compartilhá-las com seus amigos de viagem"
+        }
+      },
+      "records": {
+        "photos": "Fotos",
+        "title": "Registros",
+        "tracks": "Rotas",
+        "vocals": "Notas de voz",
+        "waypoints": "Pontos de referência"
+      },
+      "title": "Perfil",
+      "lang": "idioma",
+      "langPlaceholder": "escolher",
+      "projectlink": "Projeto",
+      "disclaimerlink": "Aviso legal",
+      "creditslink": "Créditos",
+      "privacylink": "Privacidade"
+    },
+    "register": {
+      "averagespeed": "Velocidade média",
+      "backgroundbtn": "Gravar em segundo plano",
+      "currentspeed": "Velocidade atual",
+      "modalconfirm": {
+        "cancel": "Cancelar",
+        "confirm": "Confirmar",
+        "text": "Uma vez confirmado, você não poderá reiniciar esta navegação",
+        "title": "Confirma que deseja finalizar a gravação?"
+      },
+      "modalexit": {
+        "cancel": "Cancelar",
+        "confirm": "Excluir",
+        "text": "Ao finalizar a ação, a rota será excluída do seu perfil e do Webmapp. A operação não pode ser desfeita.",
+        "title": "Excluir permanentemente?"
+      },
+      "modalphotos": {
+        "deselectall": "Desmarcar todos",
+        "noimages": "Não há imagens capturadas durante o registro da rota",
+        "savebtn": "Carregar",
+        "selectall": "Selecionar todos",
+        "title": "Carregar fotos"
+      },
+      "modalsave": {
+        "closemodal": {
+          "back": "Voltar para o registro",
+          "cancel": "Cancelar",
+          "delete": "Excluir registro"
+        },
+        "deletebtn": "SAIR SEM SALVAR",
+        "formactivity": "Tipo de atividade",
+        "formactivityerror": "O tipo de atividade é um campo obrigatório",
+        "formactivityplaceholder": "Escolher",
+        "formdescription": "Descrição",
+        "formdescriptionplaceholder": "Se desejar, você pode adicionar uma descrição",
+        "formphotos": "Adicionar fotos capturadas durante a rota",
+        "formtitle": "Título da rota",
+        "formtitleerror": "O campo de título é obrigatório",
+        "formtitleplaceholder": "Insira um título",
+        "photoaction": "Carregar",
+        "photoactionshort": "Adicionar",
+        "photoadvice": "Tamanho máximo: 3 fotos",
+        "photoadviceshort": "(máx 3 fotos)",
+        "phototext": "fotos da galeria do telefone",
+        "phototextshort": "Fotos",
+        "savebtn": "Salvar",
+        "title": "Salvar rota",
+        "titleEdit": "Modificar rota"
+      },
+      "odo": "Km percorridos",
+      "pausebtn": "Pausar",
+      "resumebtn": "Continuar",
+      "stopbtn": "Finalizar",
+      "time": "Em movimento",
+      "title": "Registrar uma rota"
+    },
+    "registeruser": {
+      "cf": "Código Fiscal",
+      "cfextra": "Por que pedimos o CF?",
+      "cfph": "XXXXXXXXXXXXXXXX",
+      "cfpopovermessage": "Se você é Membro CAI, insira seu CF durante o registro. Para você, o download das etapas do Sentiero Italia CAI será automaticamente gratuito!",
+      "cfpopovertitle": "Por que pedimos o Código Fiscal?",
+      "confirmPassword": "Confirmar senha",
+      "confirmPasswordph": "Repita a senha",
+      "email": "Email",
+      "emailph": "exemplo@email.com",
+      "errors": {
+        "form": {
+          "nameRequired": "É necessário inserir um nome"
+        },
+        "form.cfInvalid": "O código fiscal não é válido",
+        "form.confirmPasswordInvalid": "A confirmação não corresponde à senha inserida acima",
+        "form.confirmPasswordRequired": "É necessário confirmar a senha",
+        "form.emailInvalid": "Email não é válido",
+        "form.emailRequired": "É necessário inserir um email",
+        "form.passwordRequired": "É necessário inserir uma senha"
+      },
+      "genericError": "Erro ao registrar o usuário",
+      "loading": "Registrando em andamento",
+      "name": "Nome",
+      "nameph": "insira seu nome",
+      "password": "Senha",
+      "passwordph": "insira sua senha",
+      "privacy1": "Ao clicar em \"Registrar-se\" você aceita nossa ",
+      "privacy2": "e",
+      "privacy3": "",
+      "privacylink1": "Política de Privacidade",
+      "privacylink2": "Termos e condições",
+      "registerbutton": "Registrar-se",
+      "title": "Junte-se à comunidade webmapp!"
+    },
+    "route": {
+      "btnFullMapExpand": "Expandir",
+      "btnFullMapReduce": "Reduzir",
+      "btndnavigate": "Navegar",
+      "btndownload": "Baixar",
+      "btnfavourite": "Favoritos",
+      "btnshare": "Compartilhar",
+      "description": {
+        "description": "Descrição",
+        "gallery": "Galeria"
+      },
+      "detail": {
+        "from": "Partida",
+        "to": "Chegada",
+        "ascent": "Diferença de altitude +",
+        "descent": "Diferença de altitude -",
+        "distance": "Distância",
+        "duration_forward": "duração da ida",
+        "duration_backward": "duração da volta",
+        "difficulty": "Dificuldade",
+        "ele_from": "Altitude de partida",
+        "ele_max": "Altitude máxima",
+        "ele_min": "Altitude mínima",
+        "ele_to": "Altitude de chegada"
+      },
+      "directions": "Obter direções",
+      "download": "Baixar",
+      "downloadpanel": {
+        "complete": "Download concluído",
+        "dontclose": "Não feche o aplicativo durante a fase de instalação dos dados",
+        "downdata": "Baixando dados",
+        "download": "Baixar",
+        "downloadbtn": "Baixar",
+        "downloading": "Baixando",
+        "downmap": "Baixando mapa",
+        "downmedia": "Baixando mídias",
+        "downsetup": "Configuração inicial",
+        "gotobtn": "Ir para meus downloads",
+        "install": "Instalação"
+      },
+      "favbtn": {
+        "isFavourite": "Adicionado aos favoritos!",
+        "isNotFavourite": "Removido dos favoritos!"
+      },
+      "modalconfirm": {
+        "cancel": "Cancelar",
+        "confirm": "Sair",
+        "text": "Sair sem concluir o download da rota?",
+        "title": "Interromper download?"
+      },
+      "navigate": "Navegar",
+      "share": "Compartilhar",
+      "tabdescription": "Descrição",
+      "tabdetail": "Detalhes",
+      "tabeat": "Onde comer",
+      "tabhowto": "Como chegar",
+      "tabviability": "Viabilidade",
+      "tabwalkable": "Acessibilidade",
+      "viability": {
+        "info": "Outras informações",
+        "title": "Viabilidade da rota"
+      }
+    },
+    "store": {
+      "button1": "1 Moeda Única",
+      "button100": "Pacote de 100 moedas",
+      "button20": "Pacote de 20 Moedas",
+      "button50": "Pacote de 50 moedas",
+      "main": "Moedas Webmapp",
+      "text": "Você pode comprar uma Moeda única, ou escolher entre um ou mais pacotes!",
+      "text2": "As moedas servem para baixar rotas e conteúdo offline, e para acessar muitos benefícios!",
+      "title": "Loja"
+    },
+    "trackdetail": {
+      "avgspeed": "Velocidade média",
+      "delete": "Excluir registro",
+      "details": "Detalhes",
+      "distance": "Km percorridos",
+      "edit": "Modificar registro",
+      "photos": "Fotos",
+      "slope": "Diferença de altitude",
+      "time": "Tempo",
+      "title": "Rota registrada",
+      "topspeed": "Velocidade máxima"
+    },
+    "tracklist": {
+      "noitem": "Atualmente não há rotas registradas",
+      "title": "Rotas registradas"
+    },
+    "waypoint": {
+      "here": "Você está aqui:",
+      "modalsave": {
+        "formdescription": "Descrição",
+        "formdescriptionplaceholder": "Se desejar, você pode adicionar uma descrição",
+        "formoptional": "Opcional",
+        "formphotos": "Adicionar fotos do Ponto de Referência",
+        "formtitle": "Título do ponto de referência",
+        "formtitleerror": "O título do ponto de referência é obrigatório",
+        "formtitleplaceholder": "Insira um título",
+        "formtype": "Tipo de Ponto de Referência",
+        "formtypeerror": "O tipo de ponto de referência é obrigatório",
+        "formtypeplaceholder": "Escolher",
+        "photoaction": "Carregar",
+        "photoactionshort": "Adicionar",
+        "photoadvice": "Tamanho máximo: 3 fotos",
+        "photoadviceshort": "(máx 3 fotos)",
+        "phototext": "fotos da galeria do telefone",
+        "phototextshort": "Fotos",
+        "save": "Salvar ",
+        "title": "Registrar um ponto de referência"
+      },
+      "save": "Salvar ponto de referência",
+      "title": "Registrar um ponto de referência"
+    },
+    "waypointdetail": {
+      "delete": "Excluir registro",
+      "edit": "Modificar registro",
+      "title": "Ponto de referência registrado"
+    },
+    "waypointlist": {
+      "noitem": "Atualmente não há pontos de referência registrados",
+      "title": "Pontos de referência registrados"
+    },
+    "project": {
+      "title": "Projeto"
+    },
+    "credits": {
+      "title": "Créditos",
+      "webmappContent1": "O aplicativo {{appName}} é desenvolvido e mantido pela Webmapp.<br> A Webmapp realiza serviços cartográficos na internet, aplicativos móveis e cartografia impressa para Turismo de Natureza & Aventura.<br>Para mais informações, visite nosso site ",
+      "webmappContent2": " ou escreva para nós no endereço <a href=\"mailto:info@webmapp.it\">info@webmapp.it</a>",
+      "map": "Mapa",
+      "mapContent": "© Webmapp, distribuído sob licença CC BY-NC-SA",
+      "cartographicData": "Dados cartográficos",
+      "cartographicDataContent": "© Contribuidores do OpenStreetMap"
+    },
+    "disclaimer": {
+      "title": "Aviso legal",
+      "content": "Caminhar na natureza e, mais amplamente, atividades ao ar livre, são atividades potencialmente perigosas: antes de partir para uma excursão, certifique-se de que você tem o conhecimento e as habilidades para fazê-lo. Se você não tiver certeza, procure especialistas locais que possam ajudá-lo, sugerir e apoiar no planejamento e desenvolvimento de suas atividades. Os dados apresentados neste APLICATIVO não podem garantir totalmente a viabilidade sem riscos da rota: podem ter ocorrido mudanças, até mesmo significativas, desde a última verificação da rota. Portanto, é essencial que aqueles que pretendem desenvolver atividades avaliem cuidadosamente a possibilidade de prosseguir com base nas sugestões e conselhos contidos neste APLICATIVO, com base em sua experiência, condições meteorológicas (mesmo dos dias anteriores) e uma avaliação feita no local no início do desenvolvimento da atividade. A empresa Webmapp S.r.l. não oferece garantias para a segurança dos locais descritos e não assume qualquer responsabilidade por possíveis danos causados pelo desenvolvimento das atividades descritas."
+    }
+  },
+  "services": {
+    "geolocation": {
+      "notification": {
+        "text": {
+          "newTrackRecord": "Toque na notificação para abrir o aplicativo"
+        },
+        "title": {
+          "newTrackRecord": "Gravação em andamento"
+        }
+      }
+    },
+    "share": {
+      "dialogTitle": "Compartilhar com seus amigos",
+      "text": "Aqui está uma rota interessante do webmapp",
+      "title": "Você viu esta rota?",
+      "url": "www.webmapp.it"
+    }
+  },
+  "tabs": {
+    "favourites": "favoritos",
+    "home": "home",
+    "map": "mapa",
+    "profile": "perfil"
+  },
+  "no-tracks": "Você ainda não baixou nenhuma rota",
+  "hiking": "Caminhada",
+  "skitouring": "Esqui",
+  "walking": "Caminhada",
+  "running": "Corrida",
+  "asphalt": "Asfalto",
+  "bitumenduro": "Bitumenduro",
+  "onoff": "On/Off",
+  "real-dirt": "Terra real",
+  "bar": "Bar",
+  "cycling": "Ciclismo",
+  "poi_type": "ponto de interesse",
+  "where": "lugares",
+  "I tuoi dati": "Seus dados",
+  "Scarica il tracciato GPX": "Baixar a rota GPX",
+  "Scarica il tracciato KML": "Baixar a rota KML",
+  "Scarica il tracciato GEOJSON": "Baixar a rota GEOJSON",
+  "Elimina account": "Excluir conta",
+  "Vuoi veramente eliminare il tuo account? È obbligatorio scrivere 'elimina account' per procedere.": "Você realmente deseja excluir sua conta? É obrigatório escrever 'excluir conta' para prosseguir.",
+  "Digita 'elimina account'": "Digite 'excluir conta'",
+  "La conferma non corrisponde. È necessario scrivere 'elimina account' per procedere.": "A confirmação não corresponde. É necessário escrever 'excluir conta' para prosseguir.",
+  "Azione irreversibile": "Ação irreversível",
+  "Attenzione": "Atenção",
+  "Annulla": "Cancelar",
+  "Conferma": "Confirmar",
+  "Link utili": "Links úteis",
+  "Per registrare tracce e poi correttamente, abilita l'autorizzazione alla posizione nelle impostazioni": "Para registrar rotas e exibi-las corretamente, ative a permissão de localização nas configurações",
+  "Apri impostazioni App": "Abrir configurações do aplicativo"
+}

--- a/core/src/assets/i18n/sq.json
+++ b/core/src/assets/i18n/sq.json
@@ -1,0 +1,602 @@
+{
+  "activities": {
+    "cycling": "Çiklizëm",
+    "hiking": "Ecje në natyrë",
+    "running": "Vrapim",
+    "skitouring": "Skitour",
+    "walking": "Shëtitje",
+    "asphalt": "Asfalt",
+    "bitumenduro": "Bitumenduro",
+    "onoff": "On/Off",
+    "real-dirt": "Dhe i vërtetë",
+    "bar": "Bar"
+  },
+  "sidemenu": {
+    "project": "Projekti",
+    "offline": "Jashtë linje",
+    "settings": "Cilësimet",
+    "credits": "Kredite",
+    "disclaimer": "Mohim"
+  },
+  "components": {
+    "cardtrack": {
+      "delete": "Fshi",
+      "remove": "Hiq"
+    },
+    "map": {
+      "btnrec": {
+        "slide": "Rrëshqit për të regjistruar"
+      },
+      "register": {
+        "cancel": "Anulo",
+        "photo": "Foto",
+        "title": "Regjistro",
+        "track": "Gjurmë",
+        "vocal": "Shënim zanor",
+        "waypoint": "Pikë e rrugës"
+      }
+    },
+    "searchbar": {
+      "filters": "Filtro sipas",
+      "nofilters": "Asnjë filtër nuk përputhet me kërkimin e kryer",
+      "noplaces": "Asnjë vend nuk përputhet me kërkimin e kryer",
+      "notracks": "Asnjë gjurmë nuk përputhet me kërkimin e kryer",
+      "placeholder": "kërko",
+      "places": "Vende",
+      "tracks": "Gjurmë"
+    },
+    "slopechart": {
+      "slope": {
+        "label": "pjerrësi"
+      },
+      "surfaces": {
+        "asphalt": {
+          "label": "asfalt"
+        },
+        "concrete": {
+          "label": "beton"
+        },
+        "dirt": {
+          "label": "dhe"
+        },
+        "grass": {
+          "label": "bar"
+        },
+        "gravel": {
+          "label": "zhavorr"
+        },
+        "paved": {
+          "label": "i shtruar"
+        },
+        "sand": {
+          "label": "rërë"
+        }
+      }
+    }
+  },
+  "generic": {
+    "cancel": "anulo",
+    "confirm": "konfirmo",
+    "delete": "fshi",
+    "error": "Ndodhi një gabim. Provo përsëri më vonë",
+    "hour": "orë",
+    "minute": "min",
+    "ok": "ok",
+    "retry": "provo përsëri",
+    "warning": "Kujdes"
+  },
+  "modals": {
+    "coin": {
+      "buttonall": "Shiko të gjitha paketat e monedhave",
+      "buttonone": "Bli 1 Monedhë / 1€",
+      "defaultmessage": "Bli monedha për të shkarkuar përmbajtje jashtë linje",
+      "info1": "Mund të blesh një gjurmë të vetme",
+      "info2": "Ke gjithçka në dispozicion edhe pa mbulim",
+      "info3": "Merr njoftime të afërsisë",
+      "subinfo1": "Bli një monedhë të vetme për 1€",
+      "subinfo2": "Navigim i saktë edhe kur je jashtë linje",
+      "subinfo3": "Të njoftojmë në afërsi të pikave të interesit në rrugë"
+    },
+    "giftcoin": {
+      "button": "Fillo të eksplorosh",
+      "info": "Ke menjëherë dhuratë 2 monedha webmapp për të shkarkuar përmbajtje jashtë linje!",
+      "title": "Mirë se vjen në webmapp!"
+    },
+    "login": {
+      "email": "E-mail",
+      "errors": {
+        "401": "Kredencialet që ke futur nuk janë të sakta. Kontrollo e-mail dhe fjalëkalimin dhe provo përsëri",
+        "form": {
+          "emailInvalid": "Ke futur një e-mail të pavlefshëm",
+          "emailRequired": "E-mail është i detyrueshëm",
+          "passwordRequired": "Fjalëkalimi është i detyrueshëm"
+        },
+        "generic": "Oops! Diçka shkoi keq! Prit disa minuta dhe provo përsëri."
+      },
+      "forgotPassword": "Ke harruar fjalëkalimin?",
+      "login": "Hyr",
+      "message": "Hyr me kredencialet e tua për të vazhduar.",
+      "password": "Fjalëkalim",
+      "rememberLogin": "Mbaj mend kredencialet",
+      "title": "Hyr",
+      "welcome": "Mirë se u ktheve!"
+    },
+    "photo": {
+      "next": "Tjetër",
+      "popover": {
+        "cancel": "Anulo",
+        "library": "Nga biblioteka",
+        "shot": "Bëj një foto",
+        "title": "Burimi i imazhit"
+      },
+      "save": {
+        "addphoto": "Shto foto",
+        "formphototitle": "Titulli ",
+        "formtitle": "Jepi një titull fotove të tua",
+        "modalconfirm": {
+          "cancel": "Anulo",
+          "confirm": "Po, fshi",
+          "text": "Nëse e fshin nuk do të shtohet në këtë regjistrim",
+          "title": "Je i sigurt që dëshiron të fshish këtë foto nga regjistrimi?"
+        },
+        "placeholder": "Këtu mund të futësh një titull",
+        "savebtn": "Ruaj",
+        "title": "Regjistro foto"
+      },
+      "single": {
+        "formphototitle": "Titulli",
+        "placeholder": "Këtu mund të futësh një titull",
+        "savebtn": "Bërë",
+        "title": "Modifiko foto"
+      }
+    },
+    "settings": {
+      "alert": {
+        "logout": "Je i sigurt që dëshiron të ç'kyçësh llogarinë tënde?"
+      },
+      "logout": "Ç'kyçu",
+      "title": "Cilësimet",
+      "version": "Versioni"
+    },
+    "storesuccess": {
+      "back": "Kthehu te kërkimi",
+      "buttondownload": "Shkarko tani",
+      "continue": "Dëshiron të përdorësh menjëherë monedhën tënde për të shkarkuar ",
+      "continue2": "?",
+      "info": "Mund të kontrollosh bilancin e monedhave të tua direkt në zonën tënde personale!",
+      "or": "Ose",
+      "title": "Faleminderit që ke blerë monedhën tënde të parë!"
+    },
+    "success": {
+      "photos": {
+        "text": "Fotot e tua janë ruajtur me sukses. Mund t'i shikosh duke hyrë në profilin tënd.",
+        "title": "Fotot u regjistruan me sukses!"
+      },
+      "return": "Kthehu për të eksploruar",
+      "track": {
+        "avgspeed": "Shpejtësia mesatare",
+        "odo": "Km të përshkuara",
+        "slope": "Diferenca e lartësisë",
+        "text": "Gjurmët janë ruajtur me sukses. Mund t'i shikosh duke hyrë në profilin tënd.",
+        "time": "Koha",
+        "title": "Aktiviteti u regjistrua me sukses!",
+        "topspeed": "Shpejtësia maksimale"
+      },
+      "waypoint": {
+        "text": "Ke ruajtur me sukses pikën tënde të rrugës. Mund ta shikosh duke hyrë në profilin tënd.",
+        "title": "Pika e rrugës u regjistrua me sukses!"
+      }
+    }
+  },
+  "pages": {
+    "downloadlist": {
+      "cancel": "Anulo",
+      "deleteselected": "Fshi të zgjedhurat",
+      "nodata": "Nuk ke shkarkuar ende asnjë gjurmë",
+      "nodata2": "Me përmbajtjet për përdorim jashtë linje navigon me qetësi edhe pa lidhje!",
+      "nodatabtn": "Eksploro",
+      "select": "Zgjidh",
+      "title": "Shkarkime"
+    },
+    "favourites": {
+      "nodata": "Nuk ka gjurmë të preferuara, kliko mbi ikonën e zemrës së një gjurme për ta shtuar në këtë listë",
+      "title": "Të preferuarat"
+    },
+    "home": {
+      "button": "Zgjidh një pikë nisjeje",
+      "closerTracks": "Gjurmë afër",
+      "intro": "Planifikojmë së bashku aventurën tënde të ardhshme",
+      "mostViewedTracks": "Gjurmët më të shikuara",
+      "nocloserTracks": "Duket se nuk ka gjurmë afër vendndodhjes aktuale",
+      "welcome": "Mirë se vjen!"
+    },
+    "itinerary": {
+      "btnFullMapExpand": "Zgjero",
+      "btnFullMapReduce": "Redukto",
+      "btndnavigate": "Navigo",
+      "btndownload": "Shkarko",
+      "btnfavourite": "Të preferuarat",
+      "btnshare": "Ndaj",
+      "description": {
+        "description": "Përshkrimi",
+        "gallery": "Galeria"
+      },
+      "detail": {
+        "ascent": "Diferenca e lartësisë +",
+        "descent": "Diferenca e lartësisë -",
+        "distance": "Gjatësia",
+        "ele_from": "Lartësia e nisjes",
+        "ele_max": "Lartësia maksimale",
+        "ele_min": "Lartësia minimale",
+        "ele_to": "Lartësia e mbërritjes"
+      },
+      "directions": "Merr udhëzime",
+      "download": "Shkarko",
+      "downloadpanel": {
+        "complete": "Shkarkimi përfundoi",
+        "dontclose": "Mos e mbyll aplikacionin gjatë fazës së instalimit të të dhënave",
+        "downdata": "Shkarkimi i të dhënave",
+        "download": "Shkarko",
+        "downloadbtn": "Shkarko",
+        "downloading": "Duke shkarkuar",
+        "downmap": "Shkarkimi i hartës",
+        "downmedia": "Shkarkimi i mediave",
+        "downsetup": "Konfigurimi fillestar",
+        "gotobtn": "Shko te shkarkimet e mia",
+        "install": "Instalimi"
+      },
+      "favbtn": {
+        "isFavourite": "Shtuar te të preferuarat!",
+        "isNotFavourite": "Hequr nga të preferuarat!"
+      },
+      "modalconfirm": {
+        "cancel": "Anulo",
+        "confirm": "Dil",
+        "text": "Dil pa përfunduar shkarkimin e gjurmës?",
+        "title": "Ndërprerë shkarkimin?"
+      },
+      "modalNotImpemented": {
+        "text": "Së shpejti",
+        "title": "Aktualisht jo i disponueshëm",
+        "confirm": "ok"
+      },
+      "navigate": "Navigo",
+      "share": "Ndaj",
+      "tabdescription": "Përshkrimi",
+      "tabdetail": "Detajet",
+      "tabeat": "Ku të hash",
+      "tabhowto": "Si të arrish",
+      "tabviability": "Përshkueshmëria",
+      "tabwalkable": "Aksesueshmëria",
+      "viability": {
+        "info": "Informacione të tjera",
+        "title": "Praktikueshmëria e rrugës"
+      }
+    },
+    "map": {
+      "loading": "duke kërkuar...",
+      "recordingbtn": "Reg. në proces",
+      "searchherebtn": "Kërko në këtë zonë"
+    },
+    "photodetail": {
+      "delete": "Fshi regjistrimin",
+      "edit": "Modifiko regjistrimin",
+      "title": "Foto e regjistruar"
+    },
+    "photolist": {
+      "noitem": "Aktualisht nuk ka foto të regjistruara",
+      "title": "Foto të regjistruara"
+    },
+    "profile": {
+      "data": {
+        "data": "Përdorimi i të dhënave",
+        "downloads": "Shkarkime",
+        "tracks": "Gjurmë të shkarkuara"
+      },
+      "loggedOut": {
+        "login": "Hyr",
+        "signup": "Regjistrohu",
+        "slides": {
+          "0": "Hyr dhe shkarko gjurmët e tua të preferuara",
+          "1": "Mund t'i ndash edhe me shokët e udhëtimit"
+        }
+      },
+      "records": {
+        "photos": "Foto",
+        "title": "Regjistrime",
+        "tracks": "Gjurmë",
+        "vocals": "Shënime zanore",
+        "waypoints": "Pika të rrugës"
+      },
+      "title": "Profili",
+      "lang": "gjuha",
+      "langPlaceholder": "zgjidh",
+      "projectlink": "Projekti",
+      "disclaimerlink": "Mohim",
+      "creditslink": "Kredite",
+      "privacylink": "Privatësia"
+    },
+    "register": {
+      "averagespeed": "Shpejtësia mesatare",
+      "backgroundbtn": "Regjistro në sfond",
+      "currentspeed": "Shpejtësia aktuale",
+      "modalconfirm": {
+        "cancel": "Anulo",
+        "confirm": "Konfirmo",
+        "text": "Pasi të konfirmohet nuk do të mund të rifillosh këtë navigim",
+        "title": "Konfirmon që dëshiron të përfundosh regjistrimin?"
+      },
+      "modalexit": {
+        "cancel": "Anulo",
+        "confirm": "Fshi",
+        "text": "Duke përfunduar veprimin gjurma do të fshihet nga profili yt dhe nga Webmapp. Operacioni nuk mund të anulohet.",
+        "title": "Fshi përgjithmonë?"
+      },
+      "modalphotos": {
+        "deselectall": "Ç'zgjidh të gjitha",
+        "noimages": "Nuk ka imazhe të shkrepura gjatë regjistrimit të rrugës",
+        "savebtn": "Ngarko",
+        "selectall": "Zgjidh të gjitha",
+        "title": "Ngarko foto"
+      },
+      "modalsave": {
+        "closemodal": {
+          "back": "Kthehu te regjistrimi",
+          "cancel": "Anulo",
+          "delete": "Fshi regjistrimin"
+        },
+        "deletebtn": "DIL PA RUAR",
+        "formactivity": "Lloji i aktivitetit",
+        "formactivityerror": "Lloji i aktivitetit është një fushë e detyrueshme",
+        "formactivityplaceholder": "Zgjidh",
+        "formdescription": "Përshkrimi",
+        "formdescriptionplaceholder": "Nëse dëshiron mund të shtosh një përshkrim",
+        "formphotos": "Shto foto të shkrepura gjatë rrugës",
+        "formtitle": "Titulli i gjurmës",
+        "formtitleerror": "Fusha e titullit është e detyrueshme",
+        "formtitleplaceholder": "Fut një titull",
+        "photoaction": "Ngarko",
+        "photoactionshort": "Shto",
+        "photoadvice": "Madhësia maksimale: 3 foto",
+        "photoadviceshort": "(max 3 foto)",
+        "phototext": "foto nga galeria e telefonit",
+        "phototextshort": "Foto",
+        "savebtn": "Ruaj",
+        "title": "Ruaj gjurmën",
+        "titleEdit": "Modifiko gjurmën"
+      },
+      "odo": "Km të përshkuara",
+      "pausebtn": "Pauzë",
+      "resumebtn": "Vazhdo",
+      "stopbtn": "Përfundo",
+      "time": "Në lëvizje",
+      "title": "Regjistro një gjurmë"
+    },
+    "registeruser": {
+      "cf": "Kodi Fiskal",
+      "cfextra": "Pse të kërkojmë CF?",
+      "cfph": "XXXXXXXXXXXXXXXX",
+      "cfpopovermessage": "Nëse je Anëtar/Anëtare CAI fut CF-në tënde gjatë regjistrimit. Për ty shkarkimi i etapave të Sentiero Italia CAI do të jetë automatikisht falas!",
+      "cfpopovertitle": "Pse të kërkojmë Kodin Fiskal?",
+      "confirmPassword": "Konfirmo fjalëkalimin",
+      "confirmPasswordph": "Përsërit fjalëkalimin",
+      "email": "Email",
+      "emailph": "shembull@email.com",
+      "errors": {
+        "form": {
+          "nameRequired": "Është e nevojshme të futet një emër"
+        },
+        "form.cfInvalid": "Kodi fiskal nuk është i vlefshëm",
+        "form.confirmPasswordInvalid": "Konfirmimi nuk përputhet me fjalëkalimin e futur më sipër",
+        "form.confirmPasswordRequired": "Është e nevojshme të konfirmohet fjalëkalimi",
+        "form.emailInvalid": "Email nuk është i vlefshëm",
+        "form.emailRequired": "Është e nevojshme të futet një email",
+        "form.passwordRequired": "Është e nevojshme të futet një fjalëkalim"
+      },
+      "genericError": "Gabim gjatë regjistrimit të përdoruesit",
+      "loading": "Regjistrimi në proces",
+      "name": "Emri",
+      "nameph": "fut emrin tënd",
+      "password": "Fjalëkalim",
+      "passwordph": "fut fjalëkalimin",
+      "privacy1": "Duke klikuar \"Regjistrohu\" pranon tonë ",
+      "privacy2": "dhe",
+      "privacy3": "",
+      "privacylink1": "Politika e Privatësisë",
+      "privacylink2": "Kushtet dhe termat",
+      "registerbutton": "Regjistrohu",
+      "title": "Bashkohu me komunitetin e webmapp!"
+    },
+    "route": {
+      "btnFullMapExpand": "Zgjero",
+      "btnFullMapReduce": "Redukto",
+      "btndnavigate": "Navigo",
+      "btndownload": "Shkarko",
+      "btnfavourite": "Të preferuarat",
+      "btnshare": "Ndaj",
+      "description": {
+        "description": "Përshkrimi",
+        "gallery": "Galeria"
+      },
+      "detail": {
+        "from": "Nisja",
+        "to": "Mbërritja",
+        "ascent": "Diferenca e lartësisë +",
+        "descent": "Diferenca e lartësisë -",
+        "distance": "Gjatësia",
+        "duration_forward": "kohëzgjatja e shkuarjes",
+        "duration_backward": "kohëzgjatja e kthimit",
+        "difficulty": "Vështirësia",
+        "ele_from": "Lartësia e nisjes",
+        "ele_max": "Lartësia maksimale",
+        "ele_min": "Lartësia minimale",
+        "ele_to": "Lartësia e mbërritjes"
+      },
+      "directions": "Merr udhëzime",
+      "download": "Shkarko",
+      "downloadpanel": {
+        "complete": "Shkarkimi përfundoi",
+        "dontclose": "Mos e mbyll aplikacionin gjatë fazës së instalimit të të dhënave",
+        "downdata": "Shkarkimi i të dhënave",
+        "download": "Shkarko",
+        "downloadbtn": "Shkarko",
+        "downloading": "Duke shkarkuar",
+        "downmap": "Shkarkimi i hartës",
+        "downmedia": "Shkarkimi i mediave",
+        "downsetup": "Konfigurimi fillestar",
+        "gotobtn": "Shko te shkarkimet e mia",
+        "install": "Instalimi"
+      },
+      "favbtn": {
+        "isFavourite": "Shtuar te të preferuarat!",
+        "isNotFavourite": "Hequr nga të preferuarat!"
+      },
+      "modalconfirm": {
+        "cancel": "Anulo",
+        "confirm": "Dil",
+        "text": "Dil pa përfunduar shkarkimin e gjurmës?",
+        "title": "Ndërprerë shkarkimin?"
+      },
+      "navigate": "Navigo",
+      "share": "Ndaj",
+      "tabdescription": "Përshkrimi",
+      "tabdetail": "Detajet",
+      "tabeat": "Ku të hash",
+      "tabhowto": "Si të arrish",
+      "tabviability": "Përshkueshmëria",
+      "tabwalkable": "Aksesueshmëria",
+      "viability": {
+        "info": "Informacione të tjera",
+        "title": "Praktikueshmëria e rrugës"
+      }
+    },
+    "store": {
+      "button1": "1 Monedhë e Vetme",
+      "button100": "Pako 100 monedha",
+      "button20": " Pako 20 Monedha",
+      "button50": "Pako 50 monedha",
+      "main": "Monedhat Webmapp",
+      "text": "Mund të blesh një Monedhë të vetme, ose të zgjedhësh mes një ose më shumë pakove!",
+      "text2": "Monedhat shërbejnë për të shkarkuar gjurmë dhe përmbajtje jashtë linje, dhe për të aksesuar shumë përfitime!",
+      "title": "Dyqani"
+    },
+    "trackdetail": {
+      "avgspeed": "Shpejtësia mesatare",
+      "delete": "Fshi regjistrimin",
+      "details": "Detajet",
+      "distance": "Km të përshkuara",
+      "edit": "Modifiko regjistrimin",
+      "photos": "Foto",
+      "slope": "Diferenca e lartësisë",
+      "time": "Koha",
+      "title": "Gjurmë e regjistruar",
+      "topspeed": "Shpejtësia maksimale"
+    },
+    "tracklist": {
+      "noitem": "Aktualisht nuk ka gjurmë të regjistruara",
+      "title": "Gjurmë të regjistruara"
+    },
+    "waypoint": {
+      "here": "Je këtu:",
+      "modalsave": {
+        "formdescription": "Përshkrimi",
+        "formdescriptionplaceholder": "Nëse dëshiron mund të shtosh një përshkrim",
+        "formoptional": "Opsionale",
+        "formphotos": "Shto foto të Pikës së Rrugës",
+        "formtitle": "Titulli i pikës së rrugës",
+        "formtitleerror": "Titulli i pikës së rrugës është i detyrueshëm",
+        "formtitleplaceholder": "Fut një titull",
+        "formtype": "Lloji i Pikës së Rrugës",
+        "formtypeerror": "Lloji i pikës së rrugës është i detyrueshëm",
+        "formtypeplaceholder": "Zgjidh",
+        "photoaction": "Ngarko",
+        "photoactionshort": "Shto",
+        "photoadvice": "Madhësia maksimale: 3 foto",
+        "photoadviceshort": "(max 3 foto)",
+        "phototext": "foto nga galeria e telefonit",
+        "phototextshort": "Foto",
+        "save": "Ruaj ",
+        "title": "Regjistro një pikë të rrugës"
+      },
+      "save": "Ruaj pikën e rrugës",
+      "title": "Regjistro një pikë të rrugës"
+    },
+    "waypointdetail": {
+      "delete": "Fshi regjistrimin",
+      "edit": "Modifiko regjistrimin",
+      "title": "Pika e rrugës e regjistruar"
+    },
+    "waypointlist": {
+      "noitem": "Aktualisht nuk ka pika të rrugës të regjistruara",
+      "title": "Pika të rrugës të regjistruara"
+    },
+    "project": {
+      "title": "Projekti"
+    },
+    "credits": {
+      "title": "Kredite",
+      "webmappContent1": "Aplikacioni {{appName}} është zhvilluar dhe mirëmbajtur nga Webmapp.<br> Webmapp realizon shërbime kartografike në internet, aplikacione mobile, dhe kartografi të shtypur për Turizmin e Natyrës & Aventurës.<br>Për më shumë informacion vizitoni faqen tonë të internetit ",
+      "webmappContent2": " ose na shkruani në adresën <a href=\"mailto:info@webmapp.it\">info@webmapp.it</a>",
+      "map": "Harta",
+      "mapContent": "© Webmapp, shpërndarë me licencë CC BY-NC-SA",
+      "cartographicData": "Të dhënat kartografike",
+      "cartographicDataContent": "© Kontribuesit e OpenStreetMap"
+    },
+    "disclaimer": {
+      "title": "Mohim",
+      "content": "Ecja në natyrë dhe, më gjerë, aktivitetet në natyrë, janë aktivitete potencialisht të rrezikshme: para se të niseni për një ekskursion sigurohuni që keni njohuritë dhe aftësitë për ta bërë këtë. Nëse nuk jeni të sigurt, drejtohuni tek ekspertët lokalë që mund t'ju ndihmojnë, sugjerojnë dhe mbështesin në planifikimin dhe zhvillimin e aktiviteteve tuaja. Të dhënat e paraqitura në këtë APLIKACION nuk mund të garantojnë plotësisht përshkueshmërinë pa rreziqe të rrugës: mund të kenë ndodhur ndryshime, edhe të rëndësishme, që nga verifikimi i fundit i rrugës. Prandaj është thelbësore që ata që synojnë të zhvillojnë aktivitete të vlerësojnë me kujdes mundësinë e vazhdimit bazuar në sugjerimet dhe këshillat e përmbajtura në këtë APLIKACION, bazuar në përvojën e tyre, kushtet meteorologjike (edhe të ditëve të mëparshme) dhe një vlerësim të bërë në terren në fillim të zhvillimit të aktivitetit. Shoqëria Webmapp S.r.l. nuk ofron garanci për sigurinë e vendeve të përshkruara, dhe nuk merr asnjë përgjegjësi për dëmet e mundshme të shkaktuara nga zhvillimi i aktiviteteve të përshkruara."
+    }
+  },
+  "services": {
+    "geolocation": {
+      "notification": {
+        "text": {
+          "newTrackRecord": "Prek njoftimin për të hapur aplikacionin"
+        },
+        "title": {
+          "newTrackRecord": "Regjistrimi në proces"
+        }
+      }
+    },
+    "share": {
+      "dialogTitle": "Ndaj me miqtë e tu",
+      "text": "Ja një rrugë interesante nga webmapp",
+      "title": "E ke parë këtë rrugë?",
+      "url": "www.webmapp.it"
+    }
+  },
+  "tabs": {
+    "favourites": "të preferuarat",
+    "home": "kryefaqja",
+    "map": "harta",
+    "profile": "profili"
+  },
+  "no-tracks": "Nuk ke shkarkuar ende asnjë gjurmë",
+  "hiking": "Ecje në natyrë",
+  "skitouring": "Skitour",
+  "walking": "Shëtitje",
+  "running": "Vrapim",
+  "asphalt": "Asfalt",
+  "bitumenduro": "Bitumenduro",
+  "onoff": "On/Off",
+  "real-dirt": "Dhe i vërtetë",
+  "bar": "Bar",
+  "cycling": "Çiklizëm",
+  "poi_type": "pika interesi",
+  "where": "vende",
+  "I tuoi dati": "Të dhënat e tua",
+  "Scarica il tracciato GPX": "Shkarko gjurmën GPX",
+  "Scarica il tracciato KML": "Shkarko gjurmën KML",
+  "Scarica il tracciato GEOJSON": "Shkarko gjurmën GEOJSON",
+  "Elimina account": "Fshi llogarinë",
+  "Vuoi veramente eliminare il tuo account? È obbligatorio scrivere 'elimina account' per procedere.": "Dëshiron vërtet të fshish llogarinë tënde? Është e detyrueshme të shkruash 'fshi llogarinë' për të vazhduar.",
+  "Digita 'elimina account'": "Shkruaj 'fshi llogarinë'",
+  "La conferma non corrisponde. È necessario scrivere 'elimina account' per procedere.": "Konfirmimi nuk përputhet. Është e nevojshme të shkruash 'fshi llogarinë' për të vazhduar.",
+  "Azione irreversibile": "Veprim i pakthyeshëm",
+  "Attenzione": "Kujdes",
+  "Annulla": "Anulo",
+  "Conferma": "Konfirmo",
+  "Link utili": "Lidhje të dobishme",
+  "Per registrare tracce e poi correttamente, abilita l'autorizzazione alla posizione nelle impostazioni": "Për të regjistruar gjurmë dhe për t'i shfaqur ato saktë, aktivizo lejen e vendndodhjes në cilësime",
+  "Apri impostazioni App": "Hap cilësimet e aplikacionit"
+}


### PR DESCRIPTION
This commit adds the German Spanish Portuguese and Albanian translation for various components and pages in the application. It includes translations for activities, side menu, card track, map, search bar, slope chart, generic messages, modals, settings page, download list page, favourites page, home page, itinerary page, map page, photo detail page, photo list page, profile page and register page.
