### PR TITLE
chore: updates to use EnviromentService and update gulpfile oc: 5108

### DIFF
--- a/core/cypress/e2e/app_52/distance-and-duration-filters.cy.ts
+++ b/core/cypress/e2e/app_52/distance-and-duration-filters.cy.ts
@@ -1,5 +1,4 @@
-import {goHome, goMap} from 'cypress/utils/test-utils';
-import {environment} from 'src/environments/environment';
+import {confURL, goHome, goMap} from 'cypress/utils/test-utils';
 
 const minDistance = 13;
 const maxDistance = 30;
@@ -11,7 +10,6 @@ const labelDuration = 'Outward Duration';
 
 const waitFilterResults = 500;
 
-const confURL = `${environment.awsApi}/conf/52.json`;
 const filters = {
   track_duration: {
     type: 'slider',

--- a/core/cypress/e2e/app_52/favourites.cy.ts
+++ b/core/cypress/e2e/app_52/favourites.cy.ts
@@ -1,14 +1,12 @@
 import {
   clearTestState,
+  confURL,
   data,
   e2eLogin,
   goHome,
   openLayer,
   openTrack,
 } from 'cypress/utils/test-utils';
-import {environment} from 'src/environments/environment';
-
-const confURL = `${environment.awsApi}/conf/52.json`;
 
 before(() => {
   clearTestState();

--- a/core/cypress/e2e/app_52/flow-line-quote.cy.ts
+++ b/core/cypress/e2e/app_52/flow-line-quote.cy.ts
@@ -1,7 +1,5 @@
-import {data, openLayer, openTrack} from 'cypress/utils/test-utils';
-import {environment} from 'src/environments/environment';
+import {confURL, data, openLayer, openTrack} from 'cypress/utils/test-utils';
 
-const confURL = `${environment.awsApi}/conf/52.json`;
 const flowLineQuoteConfig = {
   flow_line_quote_show: true,
   flow_line_quote_orange: 1000,

--- a/core/cypress/e2e/app_52/login-offline.cy.ts
+++ b/core/cypress/e2e/app_52/login-offline.cy.ts
@@ -1,7 +1,4 @@
-import {clearTestState, confWithAuthEnabled, e2eLogin, goProfile} from 'cypress/utils/test-utils';
-import {environment} from 'src/environments/environment';
-
-const meUrl = `${environment.api}/api/auth/me`;
+import {clearTestState, confWithAuthEnabled, e2eLogin, goProfile, meUrl} from 'cypress/utils/test-utils';
 
 describe('Login offline [oc:4772] [https://orchestrator.maphub.it/resources/developer-stories/4772]', () => {
   before(() => {

--- a/core/cypress/utils/test-utils.ts
+++ b/core/cypress/utils/test-utils.ts
@@ -42,7 +42,7 @@ export function e2eLogin(
   email: string = Cypress.env('email'),
   password: string = Cypress.env('password'),
 ): Cypress.Chainable {
-  const apiLogin = `${environment.api}/api/auth/login`;
+  const apiLogin = `${environment?.shards?.geohub?.origin}/api/auth/login`;
   cy.intercept('POST', apiLogin).as('loginRequest');
   goProfile();
   cy.get('.wm-profile-logged-out-login-button').click();
@@ -84,7 +84,7 @@ export function goProfile() {
  * @returns A Cypress chainable object.
  */
 export function mockGetApiPois(mockRes: any): Cypress.Chainable {
-  return cy.intercept('GET', `${environment.api}/api/v2/ugc/poi/index`, req => {
+  return cy.intercept('GET', `${environment.shards.geohub.origin}/api/v2/ugc/poi/index`, req => {
     req.reply(res => {
       res.send(mockRes);
     });
@@ -97,7 +97,7 @@ export function mockGetApiPois(mockRes: any): Cypress.Chainable {
  * @returns A Cypress chainable object.
  */
 export function mockGetApiTracks(mockRes: any): Cypress.Chainable {
-  return cy.intercept('GET', `${environment.api}/api/v2/ugc/track/index`, req => {
+  return cy.intercept('GET', `${environment.shards.geohub.origin}/api/v2/ugc/track/index`, req => {
     req.reply(res => {
       res.send(mockRes);
     });
@@ -110,7 +110,7 @@ export function mockGetApiTracks(mockRes: any): Cypress.Chainable {
  */
 export function mockSaveApiTracksOffline(): Cypress.Chainable {
   // forceNetworkError: true, correctly simulates the network error, but still sends the track to the backend
-  return cy.intercept('POST', `${environment.api}/api/v2/ugc/track/store`, {
+  return cy.intercept('POST', `${environment.shards.geohub.origin}/api/v2/ugc/track/store`, {
     statusCode: 500,
     body: {error: 'Simulated server error'},
   });
@@ -150,7 +150,8 @@ export function openTrack(trackTitle: string) {
   });
 }
 
-const confURL = `${environment.awsApi}/conf/52.json`;
+export const meUrl = `${environment.shards.geohub.origin}/api/auth/me`;
+export const confURL = `${environment.shards.geohub.awsApi}/conf/52.json`;
 export const data = {
   layers: {
     ecTrack: 'Tracks test e2e',
@@ -159,6 +160,7 @@ export const data = {
   tracks: {
     exampleOne: 'Track example one',
     exampleTwo: 'Track example two',
+    exampleTwoRelatedPoi: 'related poi example',
   },
   pois: {
     exampleOne: 'Poi example one',

--- a/core/src/app/app.module.ts
+++ b/core/src/app/app.module.ts
@@ -20,9 +20,9 @@ import {ModalSuccessModule} from './components/modal-success/modal-success.modul
 import {SettingsModule} from './components/settings/settings.module';
 import {SharedModule} from './components/shared/shared.module';
 import packageJson from 'package.json';
-import {APP_ID, APP_VERSION, ENVIRONMENT_CONFIG} from '@wm-core/store/conf/conf.token';
-import {ConfService} from '@wm-core/store/conf/conf.service';
+import {APP_VERSION} from '@wm-core/store/conf/conf.token';
 import {StoreModule} from '@ngrx/store';
+import {EnvironmentService} from '@wm-core/services/environment.service';
 
 registerLocaleData(localeIt);
 
@@ -54,13 +54,7 @@ registerLocaleData(localeIt);
     WmCoreModule,
   ],
   providers: [
-    {provide: ENVIRONMENT_CONFIG, useValue: environment},
     {provide: LOCALE_ID, useValue: 'it'},
-    {
-      provide: APP_ID,
-      useFactory: (confSvc: ConfService) => confSvc.geohubAppId,
-      deps: [ConfService],
-    },
     {
       provide: APP_VERSION,
       useValue: packageJson.version,
@@ -69,4 +63,8 @@ registerLocaleData(localeIt);
   ],
   bootstrap: [AppComponent],
 })
-export class AppModule {}
+export class AppModule {
+  constructor(private _environmentSvc: EnvironmentService) {
+    this._environmentSvc.init(environment);
+  }
+}

--- a/core/src/app/services/base/communication.service.ts
+++ b/core/src/app/services/base/communication.service.ts
@@ -8,6 +8,7 @@
 import {Injectable} from '@angular/core';
 import {HttpClient, HttpHeaders} from '@angular/common/http';
 import {Observable} from 'rxjs';
+import {EnvironmentService} from '@wm-core/services/environment.service';
 import {environment} from 'src/environments/environment';
 
 @Injectable({
@@ -16,7 +17,7 @@ import {environment} from 'src/environments/environment';
 export class CommunicationService {
   private _token: string;
 
-  constructor(private _http: HttpClient) {}
+  constructor(private _http: HttpClient, private _environmentSvc: EnvironmentService) {}
 
   /**
    * Perform a GET request and get the result
@@ -82,7 +83,7 @@ export class CommunicationService {
       if (!options.headers) options.headers = new HttpHeaders();
 
       options.headers = options.headers.set('Authorization', `Bearer ${this._token}`);
-      options.headers = options.headers.set('App-id', `${environment.geohubId}`);
+      options.headers = options.headers.set('App-id', `${this._environmentSvc.appId}`);
     }
     return options;
   }

--- a/core/src/app/services/share.service.ts
+++ b/core/src/app/services/share.service.ts
@@ -4,6 +4,7 @@ import {environment} from 'src/environments/environment';
 import {LangService} from '@wm-core/localization/lang.service';
 import {ConfService} from '@wm-core/store/conf/conf.service';
 import {Feature, LineString} from 'geojson';
+import {EnvironmentService} from '@wm-core/services/environment.service';
 
 export interface ShareObject {
   dialogTitle?: string;
@@ -26,9 +27,8 @@ export class ShareService {
     dialogTitle: 'Share with buddies',
   };
 
-  constructor(private _translate: LangService, private _confSvc: ConfService) {
-    this._host = this._confSvc.getHost();
-    this._baseLink = this._host ? this._host : `${this._confSvc.geohubAppId}.app.webmapp.it`;
+  constructor(private _translate: LangService, private _environmentSvc: EnvironmentService) {
+    this._baseLink = this._environmentSvc.shareLink;
 
     this._translate
       .get(['services.share.title', 'services.share.url', 'services.share.dialogTitle'])
@@ -61,7 +61,7 @@ export class ShareService {
 
   public async shareRoute(route: Feature<LineString>): Promise<void> {
     return this.share({
-      url: `${DEFAULT_ROUTE_LINK_BASEURL}${route.properties.id}`,
+      url: `${this._environmentSvc.origin}/track/${route.properties.id}`,
     });
   }
 
@@ -71,5 +71,3 @@ export class ShareService {
     });
   }
 }
-
-const DEFAULT_ROUTE_LINK_BASEURL = `${environment.api}/track/`;

--- a/core/src/environments/environment.prod.ts
+++ b/core/src/environments/environment.prod.ts
@@ -1,9 +1,75 @@
-export const environment = {
+import {Environment} from '@wm-types/environment';
+
+export const environment: Environment = {
   production: true,
-  geohubId: 17,
-  api: 'https://geohub.webmapp.it',
-  elasticApi: 'https://elastic-json.webmapp.it/v2/search',
-  awsApi: 'https://wmfe.s3.eu-central-1.amazonaws.com/geohub',
-  //api: 'http://127.0.0.1:8000',
-  //elasticApi: 'http://localhost:3000/v2/search'
+  appId: 3,
+  shardName: 'geohub',
+  shards: {
+    geohub: {
+      origin: 'https://geohub.webmapp.it',
+      elasticApi: 'https://elastic-json.webmapp.it/v2/search',
+      graphhopperHost: 'https://graphhopper.webmapp.it/',
+      awsApi: 'https://wmfe.s3.eu-central-1.amazonaws.com/geohub',
+    },
+    osm2cai: {
+      origin: 'https://osm2cai.webmapp.it',
+      elasticApi: 'https://elastic-json.webmapp.it/v2/search',
+      graphhopperHost: 'https://graphhopper.webmapp.it/',
+      awsApi: 'https://wmfe.s3.eu-central-1.amazonaws.com/geohub',
+    },
+    camminiditalia: {
+      origin: 'https://camminiditalia.maphub.it',
+      elasticApi: 'https://elastic-json.webmapp.it/v2/search',
+      graphhopperHost: 'https://graphhopper.webmapp.it/',
+      awsApi: 'https://wmfe.s3.eu-central-1.amazonaws.com/camminiditalia',
+    },
+    carg: {
+      origin: 'https://carg.webmapp.it',
+      elasticApi: 'https://elastic-json.webmapp.it/v2/search',
+      graphhopperHost: 'https://graphhopper.webmapp.it/',
+      awsApi: 'https://wmfe.s3.eu-central-1.amazonaws.com/geohub',
+    },
+  },
+  redirects: {
+    'sentieri.caiparma.it': {
+      shardName: 'geohub',
+      appId: 33,
+    },
+    'motomappa.motoabbigliamento.it': {
+      shardName: 'geohub',
+      appId: 53,
+    },
+    'maps.parcoforestecasentinesi.it': {
+      shardName: 'geohub',
+      appId: 49,
+    },
+    'maps.parcopan.org': {
+      shardName: 'geohub',
+      appId: 63,
+    },
+    'maps.acquasorgente.cai.it': {
+      shardName: 'geohub',
+      appId: 58,
+    },
+    'maps.caipontedera.it': {
+      shardName: 'geohub',
+      appId: 59,
+    },
+    'maps.parcapuane.it': {
+      shardName: 'geohub',
+      appId: 62,
+    },
+    'fiemaps.it': {
+      shardName: 'geohub',
+      appId: 29,
+    },
+    'fiemaps.eu': {
+      shardName: 'geohub',
+      appId: 29,
+    },
+    'maps.sentierodeiducati.it': {
+      shardName: 'geohub',
+      appId: 60,
+    },
+  },
 };

--- a/core/src/environments/environment.ts
+++ b/core/src/environments/environment.ts
@@ -2,17 +2,80 @@
 // `ng build --prod` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
 
-export const environment = {
+import {Environment} from '@wm-types/environment';
+
+export const environment: Environment = {
   production: false,
-  analyticsId: '285809815',
-  geohubId: 3,
-  apiCarg: 'https://carg.maphub.it',
-  elasticApi: 'https://elastic-json.webmapp.it/v2/search',
-  osm2caiApi: 'https://osm2cai.cai.it',
-  api: 'https://geohub.webmapp.it',
-  awsApi: 'https://wmfe.s3.eu-central-1.amazonaws.com/geohub',
-  // api: 'http://127.0.0.1:8000',
-  //elasticApi: 'http://localhost:3000/v2/search'
+  appId: 3,
+  shardName: 'geohub',
+  shards: {
+    geohub: {
+      origin: 'https://geohub.webmapp.it',
+      elasticApi: 'https://elastic-json.webmapp.it/v2/search',
+      graphhopperHost: 'https://graphhopper.webmapp.it/',
+      awsApi: 'https://wmfe.s3.eu-central-1.amazonaws.com/geohub',
+    },
+    osm2cai: {
+      origin: 'https://osm2cai.webmapp.it',
+      elasticApi: 'https://elastic-json.webmapp.it/v2/search',
+      graphhopperHost: 'https://graphhopper.webmapp.it/',
+      awsApi: 'https://wmfe.s3.eu-central-1.amazonaws.com/geohub',
+    },
+    camminiditalia: {
+      origin: 'https://camminiditalia.maphub.it',
+      elasticApi: 'https://elastic-json.webmapp.it/v2/search',
+      graphhopperHost: 'https://graphhopper.webmapp.it/',
+      awsApi: 'https://wmfe.s3.eu-central-1.amazonaws.com/camminiditalia',
+    },
+    carg: {
+      origin: 'https://carg.webmapp.it',
+      elasticApi: 'https://elastic-json.webmapp.it/v2/search',
+      graphhopperHost: 'https://graphhopper.webmapp.it/',
+      awsApi: 'https://wmfe.s3.eu-central-1.amazonaws.com/geohub',
+    },
+  },
+  redirects: {
+    'sentieri.caiparma.it': {
+      shardName: 'geohub',
+      appId: 33,
+    },
+    'motomappa.motoabbigliamento.it': {
+      shardName: 'geohub',
+      appId: 53,
+    },
+    'maps.parcoforestecasentinesi.it': {
+      shardName: 'geohub',
+      appId: 49,
+    },
+    'maps.parcopan.org': {
+      shardName: 'geohub',
+      appId: 63,
+    },
+    'maps.acquasorgente.cai.it': {
+      shardName: 'geohub',
+      appId: 58,
+    },
+    'maps.caipontedera.it': {
+      shardName: 'geohub',
+      appId: 59,
+    },
+    'maps.parcapuane.it': {
+      shardName: 'geohub',
+      appId: 62,
+    },
+    'fiemaps.it': {
+      shardName: 'geohub',
+      appId: 29,
+    },
+    'fiemaps.eu': {
+      shardName: 'geohub',
+      appId: 29,
+    },
+    'maps.sentierodeiducati.it': {
+      shardName: 'geohub',
+      appId: 60,
+    },
+  },
 };
 
 /*
@@ -22,4 +85,4 @@ export const environment = {
  * This import should be commented out in production mode because it will have a negative impact
  * on performance if an error is thrown.
  */
-// import 'zone.js/plugins/zone-error'; // Included with Angular CLI.
+// import 'zone.js/dist/zone-error'; // Included with Angular CLI.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -339,8 +339,12 @@ function update(instanceName, geohubInstanceId, shardName) {
 
     if (argv.url) url = argv.url;
     else {
-      url = envJson.shards[shardName].origin + '/api/app/webmapp/' + geohubInstanceId;
-      console.log(config);
+      const shard = envJson.shards?.[shardName] ?? null;
+      if (!shard) {
+        reject(`Error: shard "${shardName}" not found in environment`);
+        return;
+      }
+      url = shard?.origin + '/api/app/webmapp/' + geohubInstanceId;
       if (verbose) debug('Using default url: ' + url);
     }
 
@@ -1764,7 +1768,7 @@ function getJsonEnvironment() {
   }
   const fileEnv = fs.readFileSync(envPath, 'utf8');
   const envMatch = fileEnv.match(/export const environment: Environment = ({[\s\S]*?});/);
-  if (!envMatch) {
+  if (!envMatch || !envMatch[1]) {
     reject("Impossibile trovare l'oggetto environment nel file");
     return;
   }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -150,6 +150,13 @@ const argv = yargs(hideBin(process.argv))
       describe: 'Set the bundle version for the ios build',
       type: 'boolean',
     },
+    s: {
+      alias: 'shardName',
+      demandOption: true,
+      default: 'geohub',
+      describe: 'Set the shard name to work with',
+      type: 'string',
+    },
     force: {
       demandOption: false,
       default: false,
@@ -311,7 +318,7 @@ function create(instanceName, force) {
   });
 }
 
-function update(instanceName, geohubInstanceId) {
+function update(instanceName, geohubInstanceId, shardName) {
   return new Promise((resolve, reject) => {
     if (!instanceName) {
       reject('Instance name required. See gulp help');
@@ -323,12 +330,16 @@ function update(instanceName, geohubInstanceId) {
       return;
     }
 
+    const envJson = getJsonEnvironment();
+    envJson.appId = geohubInstanceId;
+    envJson.shardName = shardName;
+
     var dir = instancesDir + instanceName,
       url = '';
 
     if (argv.url) url = argv.url;
     else {
-      url = API + '/api/app/webmapp/' + geohubInstanceId;
+      url = envJson.shards[shardName].origin + '/api/app/webmapp/' + geohubInstanceId;
       console.log(config);
       if (verbose) debug('Using default url: ' + url);
     }
@@ -418,17 +429,8 @@ function update(instanceName, geohubInstanceId) {
       reject('Missing instance. See gulp help for more');
     }
     console.log(config);
-    // enviroment.ts
-    const env = `
-export const environment = {
-  production: false,
-  geohubId: ${geohubInstanceId},
-  analyticsId:'285809815',
-  api: '${API}',
-  awsApi: 'https://wmfe.s3.eu-central-1.amazonaws.com/geohub',
-  elasticApi: 'https://elastic-json.webmapp.it/v2/search',
-};
-`;
+
+    const env = `export const environment = ${JSON.stringify(envJson)};`;
     fs.writeFileSync(instancesDir + instanceName + '/src/environments/environment.ts', env);
   });
 }
@@ -693,7 +695,7 @@ function updateGradleVersion(instanceName, newVersion) {
   });
 }
 
-function build(instanceName, geohubInstanceId) {
+function build(instanceName, geohubInstanceId, shardName) {
   // setAPI(instanceName);
   return new Promise((resolve, reject) => {
     if (!instanceName) {
@@ -718,7 +720,7 @@ function build(instanceName, geohubInstanceId) {
       function () {
         if (verbose) debug('`build()` - create completed');
         if (verbose) debug('`build()`- running `update()`');
-        update(instanceName, geohubInstanceId).then(
+        update(instanceName, geohubInstanceId, shardName).then(
           result => {
             if (verbose) debug('`build()` - update completed');
             if (verbose) debug('`build()` completed');
@@ -739,10 +741,10 @@ function build(instanceName, geohubInstanceId) {
   });
 }
 
-function buildAndroid(instanceName, geohubInstanceId) {
+function buildAndroid(instanceName, geohubInstanceId, shardName) {
   //setAPI(instanceName);
   return new Promise((resolve, reject) => {
-    build(instanceName, geohubInstanceId).then(
+    build(instanceName, geohubInstanceId, shardName).then(
       result => {
         if (!result.id) {
           abort('The app id could not be found');
@@ -1187,10 +1189,10 @@ function updateIosPlatform(instanceName, appId, appName) {
   });
 }
 
-function buildIos(instanceName, geohubInstanceId) {
+function buildIos(instanceName, geohubInstanceId, shardName) {
   return new Promise((resolve, reject) => {
     //setAPI(instanceName);
-    build(instanceName, geohubInstanceId).then(
+    build(instanceName, geohubInstanceId, shardName).then(
       result => {
         if (!result.id) {
           abort('The app id could not be found');
@@ -1432,7 +1434,8 @@ gulp.task('build', function (done) {
  */
 gulp.task('build-android', function (done) {
   var instanceName = argv.instance ? argv.instance : '',
-    geohubInstanceId = argv.geohubInstanceId ? argv.geohubInstanceId : '';
+    geohubInstanceId = argv.geohubInstanceId ? argv.geohubInstanceId : '',
+    shardName = argv.shardName ? argv.shardName : 'geohub';
 
   if (verbose) debug('Building android platform for instance ' + instanceName);
   if (!instanceName) {
@@ -1446,7 +1449,7 @@ gulp.task('build-android', function (done) {
     return;
   }
 
-  buildAndroid(instanceName, geohubInstanceId).then(
+  buildAndroid(instanceName, geohubInstanceId, shardName).then(
     () => {
       done();
     },
@@ -1622,7 +1625,8 @@ gulp.task('build-android-bundle', function (done) {
  */
 gulp.task('build-ios', function (done) {
   var instanceName = argv.instance ? argv.instance : '',
-    geohubInstanceId = argv.geohubInstanceId ? argv.geohubInstanceId : '';
+    geohubInstanceId = argv.geohubInstanceId ? argv.geohubInstanceId : '',
+    shardName = argv.shardName ? argv.shardName : 'geohub';
   if (!instanceName) {
     abort('Instance name requred. See gulp help');
     done();
@@ -1635,7 +1639,7 @@ gulp.task('build-ios', function (done) {
   }
 
   if (verbose) debug('Building iOS platform for instance ' + instanceName);
-  buildIos(instanceName, geohubInstanceId).then(
+  buildIos(instanceName, geohubInstanceId, shardName).then(
     () => {
       done();
     },
@@ -1750,4 +1754,20 @@ function addPermissionsIfNotPresent() {
     this.push(file);
     callback();
   });
+}
+
+function getJsonEnvironment() {
+  const envPath = 'core/src/environments/environment.ts';
+  if (!fs.existsSync(envPath)) {
+    reject(`File ${envPath} non trovato.`);
+    return;
+  }
+  const fileEnv = fs.readFileSync(envPath, 'utf8');
+  const envMatch = fileEnv.match(/export const environment: Environment = ({[\s\S]*?});/);
+  if (!envMatch) {
+    reject("Impossibile trovare l'oggetto environment nel file");
+    return;
+  }
+
+  return eval('(' + envMatch[1] + ')');
 }


### PR DESCRIPTION
- Added import for EnvironmentService in communication.service.ts, geohub.service.ts, and share.service.ts
- Injected EnvironmentService in the constructors of CommunicationService, GeohubService, and ShareService
- Updated API URLs to use the origin property from EnvironmentService instead of hardcoding them

chore: Update app.module.ts

- Removed unused imports and providers
- Added initialization of EnvironmentService in AppModule constructor

Updated submodule core/src/app/shared/wm-core

chore: Update gulpfile.js

This commit updates the gulpfile.js file with the following changes:
- Added a new option to set the shard name to work with
- Modified the update() function to include the shard name parameter
- Updated the build() and buildAndroid() functions to include the shard name parameter
- Updated the buildIos() function to include the shard name parameter

chore: Update appId value in environment.ts file

The appId value in the environment.ts file was updated from 75 to 3. This change ensures that the correct application ID is used for the geohub shard.

chore: Update share service to use environment variable

The share service has been updated to use the `shareLink` property from the `EnvironmentService` instead of retrieving the host dynamically. This change ensures that the correct base link is used for sharing functionality.
