### PR TITLE
chore: update layers view oc: 5201

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,189 @@
 {
   "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true,
+  "prettier.singleQuote": true,
   "prettier.configPath": ".prettierrc",
-  "[typescript]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
-  }
+  "tsco.addPublicModifierIfMissing": false,
+  "tsco.addRegionCaptionToRegionEnd": false,
+  "tsco.organizeOnSave": true,
+  "tsco.groupPropertiesWithDecorators": true,
+  "tsco.useRegions": false,
+  "tsco.addMemberCountInRegionName": false,
+  "tsco.memberOrder": [
+    {
+      "caption": "Properties",
+      "memberTypes": [
+        "privateStaticConstProperties",
+        "privateConstProperties",
+        "privateStaticReadOnlyProperties",
+        "privateReadOnlyProperties",
+        "privateStaticProperties",
+        "privateProperties",
+        "protectedStaticConstProperties",
+        "protectedConstProperties",
+        "protectedStaticReadOnlyProperties",
+        "protectedReadOnlyProperties",
+        "protectedStaticProperties",
+        "protectedProperties",
+        "publicStaticConstProperties",
+        "publicConstProperties",
+        "publicStaticReadOnlyProperties",
+        "publicReadOnlyProperties",
+        "publicStaticProperties",
+        "publicProperties"
+      ]
+    },
+    {
+      "caption": "Static Block Declarations",
+      "memberTypes": ["staticBlockDeclarations"]
+    },
+    {
+      "caption": "Constructors",
+      "memberTypes": ["constructors"]
+    },
+    {
+      "caption": "Public Static Indexers",
+      "memberTypes": ["publicStaticIndexes"]
+    },
+    {
+      "caption": "Public Indexers",
+      "memberTypes": ["publicIndexes"]
+    },
+    {
+      "caption": "Public Abstract Indexers",
+      "memberTypes": ["publicAbstractIndexes"]
+    },
+    {
+      "caption": "Protected Static Indexers",
+      "memberTypes": ["protectedStaticIndexes"]
+    },
+    {
+      "caption": "Protected Indexers",
+      "memberTypes": ["protectedIndexes"]
+    },
+    {
+      "caption": "Protected Abstract Indexers",
+      "memberTypes": ["protectedAbstractIndexes"]
+    },
+    {
+      "caption": "Private Static Indexers",
+      "memberTypes": ["privateStaticIndexes"]
+    },
+    {
+      "caption": "Private Indexers",
+      "memberTypes": ["privateIndexes"]
+    },
+    {
+      "caption": "Private Abstract Indexers",
+      "memberTypes": ["privateAbstractIndexes"]
+    },
+    {
+      "caption": "Public Static Accessors",
+      "memberTypes": ["publicStaticAccessors"]
+    },
+    {
+      "caption": "Public Accessors",
+      "memberTypes": ["publicAccessors"]
+    },
+    {
+      "caption": "Public Abstract Accessors",
+      "memberTypes": ["publicAbstractAccessors"]
+    },
+    {
+      "caption": "Protected Static Accessors",
+      "memberTypes": ["protectedStaticAccessors"]
+    },
+    {
+      "caption": "Protected Accessors",
+      "memberTypes": ["protectedAccessors"]
+    },
+    {
+      "caption": "Protected Abstract Accessors",
+      "memberTypes": ["protectedAbstractAccessors"]
+    },
+    {
+      "caption": "Private Static Accessors",
+      "memberTypes": ["privateStaticAccessors"]
+    },
+    {
+      "caption": "Private Accessors",
+      "memberTypes": ["privateAccessors"]
+    },
+    {
+      "caption": "Private Abstract Accessors",
+      "memberTypes": ["privateAbstractAccessors"]
+    },
+    {
+      "caption": "Public Static Getters And Setters",
+      "memberTypes": ["publicStaticGettersAndSetters"]
+    },
+    {
+      "caption": "Public Getters And Setters",
+      "memberTypes": ["publicGettersAndSetters"]
+    },
+    {
+      "caption": "Public Abstract Getters And Setters",
+      "memberTypes": ["publicAbstractGettersAndSetters"]
+    },
+    {
+      "caption": "Protected Static Getters And Setters",
+      "memberTypes": ["protectedStaticGettersAndSetters"]
+    },
+    {
+      "caption": "Protected Getters And Setters",
+      "memberTypes": ["protectedGettersAndSetters"]
+    },
+    {
+      "caption": "Protected Abstract Getters And Setters",
+      "memberTypes": ["protectedAbstractGettersAndSetters"]
+    },
+    {
+      "caption": "Private Static Getters And Setters",
+      "memberTypes": ["privateStaticGettersAndSetters"]
+    },
+    {
+      "caption": "Private Getters And Setters",
+      "memberTypes": ["privateGettersAndSetters"]
+    },
+    {
+      "caption": "Private Abstract Getters And Setters",
+      "memberTypes": ["privateAbstractGettersAndSetters"]
+    },
+    {
+      "caption": "Public Static Methods",
+      "memberTypes": ["publicStaticMethods"]
+    },
+    {
+      "caption": "Public Methods",
+      "memberTypes": ["publicMethods"]
+    },
+    {
+      "caption": "Public Abstract Methods",
+      "memberTypes": ["publicAbstractMethods"]
+    },
+    {
+      "caption": "Protected Static Methods",
+      "memberTypes": ["protectedStaticMethods"]
+    },
+    {
+      "caption": "Protected Methods",
+      "memberTypes": ["protectedMethods"]
+    },
+    {
+      "caption": "Protected Abstract Methods",
+      "memberTypes": ["protectedAbstractMethods"]
+    },
+    {
+      "caption": "Private Static Methods",
+      "memberTypes": ["privateStaticMethods"]
+    },
+    {
+      "caption": "Private Methods",
+      "memberTypes": ["privateMethods"]
+    },
+    {
+      "caption": "Private Abstract Methods",
+      "memberTypes": ["privateAbstractMethods"]
+    }
+  ]
 }

--- a/core/src/app/pages/map/map-details/map-details.component.scss
+++ b/core/src/app/pages/map/map-details/map-details.component.scss
@@ -45,7 +45,7 @@ wm-map-details {
     margin-inline: 0 !important;
     margin: 0;
     padding: 10px;
-    height: 100%;
+    height: inherit;
     padding-bottom: 15%;
     > ion-card-header {
       margin: 0;
@@ -77,13 +77,23 @@ wm-map-details {
         }
       }
     }
-    ion-card-content {
+    > ion-card-content {
       height: 100%;
       top: 70px;
       overflow-y: auto;
       overflow-x: hidden;
       padding: 0 !important;
       margin: 0 !important;
+
+      wm-status-filter {
+        > ion-grid {
+          > ion-row {
+            > ion-col:nth-of-type(2) {
+              display: none;
+            }
+          }
+        }
+      }
 
       wm-poi-properties {
         position: relative;

--- a/core/src/app/pages/map/map-details/map-details.component.ts
+++ b/core/src/app/pages/map/map-details/map-details.component.ts
@@ -53,6 +53,14 @@ export class MapDetailsComponent implements AfterViewInit {
   ngAfterViewInit(): void {
     this.setAnimations();
     this._setGesture();
+    /* TODO: modificare gli status del map details, dovrebbero essere solo 4:
+      background, onlyTitle, open, full che corrispondono alle 4 posizioni del map details,
+      chiuso, aperto solo con titolo, aperto, aperto completo.
+      Questo per gestire la transizione tra le varie posizioni. Attualmente "none()" è una funzione usata per verificare
+      se c'è ad esempio un releted_poi aperto e nel caso chiudere solo il releted e non la traccia, quindi non sempre
+      chiude il dettaglio, impendendomi ai successivi click del back button di chiudere il dettaglio
+      (essendo già il suo stato a none).
+    */
     this._store.select(mapDetailsStatus).subscribe(status => {
       switch (status) {
         case 'open':
@@ -69,6 +77,9 @@ export class MapDetailsComponent implements AfterViewInit {
           break;
         case 'toggle':
           this.toggle();
+          break;
+        case 'full':
+          this.full();
           break;
       }
     });
@@ -97,13 +108,13 @@ export class MapDetailsComponent implements AfterViewInit {
     const queryParams = this._urlHandlerSvc.getCurrentQueryParams();
     if (queryParams.poi != null) {
       this._urlHandlerSvc.updateURL({poi: undefined});
-      this.background();
+      this._store.dispatch(setMapDetailsStatus({status: 'background'}));
     } else if (queryParams.ec_related_poi != null) {
       this._urlHandlerSvc.updateURL({ec_related_poi: undefined});
     } else if (queryParams.ugc_poi != null) {
       this._urlHandlerSvc.updateURL({ugc_poi: undefined});
     } else {
-      this.background();
+      this._store.dispatch(setMapDetailsStatus({status: 'background'}));
       this._urlHandlerSvc.updateURL({track: undefined, ugc_track: undefined});
     }
 
@@ -141,10 +152,10 @@ export class MapDetailsComponent implements AfterViewInit {
 
   toggle(): boolean {
     if (this._getCurrentHeight() > this.maxInfoheight / 2 || this._getCurrentHeight() <= 110) {
-      this.open();
+      this._store.dispatch(setMapDetailsStatus({status: 'open'}));
       return true;
     } else {
-      this.onlyTitle();
+      this._store.dispatch(setMapDetailsStatus({status: 'onlyTitle'}));
       return false;
     }
   }
@@ -170,9 +181,9 @@ export class MapDetailsComponent implements AfterViewInit {
         this.toggleEVT.emit();
 
         if (this._getCurrentHeight() > this.minInfoheight || this._getCurrentHeight() === 56) {
-          this.open();
+          this._store.dispatch(setMapDetailsStatus({status: 'open'}));
         } else {
-          this.full();
+          this._store.dispatch(setMapDetailsStatus({status: 'full'}));
         }
       },
       onEnd: ev => {

--- a/core/src/app/pages/map/map.page.html
+++ b/core/src/app/pages/map/map.page.html
@@ -1,4 +1,4 @@
-<ion-content scrollY="false">
+<ion-content scrollY="false" [class.full-details]="(mapDetailsStatus$|async) === 'full'">
   <wm-geobox-map #geoboxMap (openPopupEVT)="openPopup($event)">
     <wm-map-details #details (closeEVT)="close()">
       <div header>
@@ -50,6 +50,7 @@
         </div>
       </div>
       <ng-container *ngIf="!(featureOpened$|async)">
+        <wm-status-filter></wm-status-filter>
         <wm-home-layer></wm-home-layer>
         <wm-home-result></wm-home-result>
       </ng-container>

--- a/core/src/app/pages/map/map.page.scss
+++ b/core/src/app/pages/map/map.page.scss
@@ -114,4 +114,17 @@ webmapp-map-page {
   ion-title {
     font-size: unset;
   }
+
+  .bottom-right,
+  .ol-zoom {
+    opacity: 1;
+    transition: opacity 0.3s ease-in-out;
+  }
+  .full-details {
+    .bottom-right,
+    .ol-zoom {
+      opacity: 0;
+      pointer-events: none;
+    }
+  }
 }

--- a/core/src/app/pages/map/map.page.ts
+++ b/core/src/app/pages/map/map.page.ts
@@ -39,7 +39,11 @@ import {isLogged} from '@wm-core/store/auth/auth.selectors';
 import {hitMapFeatureCollection} from 'src/app/shared/map-core/src/store/map-core.selector';
 import {DeviceService} from '@wm-core/services/device.service';
 import {GeolocationService} from '@wm-core/services/geolocation.service';
-import {ecLayer, inputTyped} from '@wm-core/store/user-activity/user-activity.selector';
+import {
+  ecLayer,
+  inputTyped,
+  mapDetailsStatus,
+} from '@wm-core/store/user-activity/user-activity.selector';
 import {WmFeature} from '@wm-types/feature';
 import {featureOpened, poi, track} from '@wm-core/store/features/features.selector';
 import {UrlHandlerService} from '@wm-core/services/url-handler.service';
@@ -53,7 +57,7 @@ import {WmGeoboxMapComponent} from '@wm-core/geobox-map/geobox-map.component';
 import {online} from '@wm-core/store/network/network.selector';
 import {INetworkRootState} from '@wm-core/store/network/netwotk.reducer';
 import {setMapDetailsStatus} from '@wm-core/store/user-activity/user-activity.action';
-
+import {mapDetailsStatus as mapDetailsStatusType} from '@wm-core/store/user-activity/user-activity.reducer';
 export interface IDATALAYER {
   high: string;
   low: string;
@@ -137,6 +141,7 @@ export class MapPage {
   isTrackRecordingEnable$: Observable<boolean> = this._store.select(confRecordTrackShow);
   lang = localStorage.getItem('wm-lang') || 'it';
   layerOpacity$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
+  mapDetailsStatus$: Observable<mapDetailsStatusType> = this._store.select(mapDetailsStatus);
   modeFullMap = false;
   nearestPoi$: BehaviorSubject<Feature<Geometry> | null> =
     new BehaviorSubject<Feature<Geometry> | null>(null);


### PR DESCRIPTION
chore: Update .vscode/settings.json

- Enable format on save
- Set singleQuote option to true in Prettier configuration
- Disable adding public modifier if missing in TypeScript code organization
- Disable adding region caption to region end in TypeScript code organization
- Enable organizing imports on save in TypeScript code organization
- Group properties with decorators in TypeScript code organization

chore: Update map page HTML, SCSS, and TypeScript files

- Added [class.full-details] binding to ion-content in map.page.html
- Added styles for .bottom-right and .ol-zoom classes in map.page.scss
- Updated imports and added mapDetailsStatus selector in map.page.ts

chore: Update map-details component styles

- Set the height of wm-map-details to inherit instead of 100%
- Add a style rule to hide ion-col:nth-of-type(2) inside wm-status-filter
- Remove unnecessary padding and margin rules from ion-card-content

feat: Modify map details status handling

- Add a TODO comment explaining the desired changes to the status handling
- Dispatch actions based on different status values in ngAfterViewInit()
- Add new cases for 'full' and 'toggle' statuses
- Replace calls to open(), onlyTitle(), and background() with dispatching actions
