### PR TITLE
fix: app translations for Italian, English, and French languages

### DIFF
--- a/core/src/app/app.component.ts
+++ b/core/src/app/app.component.ts
@@ -59,6 +59,9 @@ export class AppComponent {
     this._store.dispatch(syncUgc());
     this.confTHEMEVariables$.pipe(take(2)).subscribe(css => this._setGlobalCSS(css));
     this._storeNetwork.dispatch(startNetworkMonitoring());
+    this._langService.setTranslation('it', appIT, true);
+    this._langService.setTranslation('en', appEN, true);
+    this._langService.setTranslation('fr', appFR, true);
     this._store
       .select(confLANGUAGES)
       .pipe(
@@ -66,9 +69,6 @@ export class AppComponent {
         take(1),
       )
       .subscribe(l => {
-        this._langService.setTranslation('it', appIT, true);
-        this._langService.setTranslation('en', appEN, true);
-        this._langService.setTranslation('fr', appFR, true);
         this._langService.initLang(l.default);
       });
     this._platform.ready().then(


### PR DESCRIPTION
This commit adds translations for the Italian, English, and French languages in the app component. The translations are set using the `_langService.setTranslation` method.
