### PR TITLE
chore(poi-properties): add support for embedded elements co:5441

### DIFF
--- a/core/src/app/components/poi-properties/poi-properties.component.html
+++ b/core/src/app/components/poi-properties/poi-properties.component.html
@@ -35,5 +35,11 @@
       </a>
     </div>
     <wm-track-audio *ngIf="properties?.audio" [audio]="properties?.audio"></wm-track-audio>
+    <wm-inner-component-html
+      *ngIf="properties?.embeddedElement as embeddedElement"
+      [enableDismiss]="false"
+      [title]="embeddedElement?.title"
+      [html]="embeddedElement?.html"
+    ></wm-inner-component-html>
   </div>
 </ng-container>


### PR DESCRIPTION
This commit adds support for displaying embedded elements in the POI properties component. The embedded element is conditionally rendered based on the presence of the "embeddedElement" property.
