### PR TITLE
🔧 chore(map-details): add close event emitter oc:5573

### DIFF
--- a/core/cypress/e2e/app_52/download-ec-track.cy.ts
+++ b/core/cypress/e2e/app_52/download-ec-track.cy.ts
@@ -32,5 +32,5 @@ function getDownloadButton() {
 }
 
 function getGoToDownloadsButton() {
-  return cy.get('wm-download ion-button.webmapp-downloadpanel-button', {timeout: 12500});
+  return cy.get('wm-download ion-button.webmapp-downloadpanel-button', {timeout: 15000});
 }

--- a/core/src/app/pages/map/map-details/map-details.component.ts
+++ b/core/src/app/pages/map/map-details/map-details.component.ts
@@ -3,6 +3,8 @@ import {
   ChangeDetectionStrategy,
   Component,
   ElementRef,
+  EventEmitter,
+  Output,
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
@@ -31,6 +33,7 @@ export class MapDetailsComponent implements AfterViewInit {
   private _initialStep: number = 1;
   private _started: boolean = false;
 
+  @Output() closeEVT: EventEmitter<void> = new EventEmitter<void>();
   @ViewChild('dragHandleIcon') dragHandleIcon: ElementRef;
 
   height = 700;
@@ -91,6 +94,7 @@ export class MapDetailsComponent implements AfterViewInit {
 
   back(): void {
     this._store.dispatch(backOfMapDetails());
+    this.closeEVT.emit();
   }
 
   onlyTitle(): void {

--- a/core/src/app/pages/map/map.page.html
+++ b/core/src/app/pages/map/map.page.html
@@ -200,7 +200,7 @@
       [overlayUrls]="overlayFeatureCollections$|async"
       [overlayXYZ]="'https://tiles.webmapp.it/carg'"
       [overlayGeometry]="hitMapGeometry$|async"
-      (closeEvt)="showDownload$.next(false);mapDetailsCmp.open()"
+      (closeEvt)="closeDownload()"
       (goToEvt)="goToPage($event)"
     ></wm-download>
   </wm-geobox-map>

--- a/core/src/app/pages/map/map.page.ts
+++ b/core/src/app/pages/map/map.page.ts
@@ -239,6 +239,16 @@ export class MapPage {
     this.showDownload$.next(false);
     this.wmMapPositionfocus$.next(false);
     this.resetSelectedPopup$.next(!this.resetSelectedPopup$.value);
+    this.popup$.next(null);
+  }
+
+  closeDownload(): void {
+    this.showDownload$.next(false);
+    this.currentTrack$.pipe(take(1)).subscribe(track => {
+      if (track != null || this.popup$.value != null) {
+        this._store.dispatch(setMapDetailsStatus({status: 'open'}));
+      }
+    });
   }
 
   async favourite(trackID): Promise<void> {

--- a/core/src/app/pages/tabs/tabs.page.ts
+++ b/core/src/app/pages/tabs/tabs.page.ts
@@ -6,7 +6,11 @@ import {IonTabs} from '@ionic/angular';
 import {confAUTHEnable} from '@wm-core/store/conf/conf.selector';
 import {isLogged} from '@wm-core/store/auth/auth.selectors';
 import {UrlHandlerService} from '@wm-core/services/url-handler.service';
-import {goToHome, resetMap} from '@wm-core/store/user-activity/user-activity.action';
+import {
+  goToHome,
+  resetMap,
+  wmMapHitMapChangeFeatureById,
+} from '@wm-core/store/user-activity/user-activity.action';
 import {online} from '@wm-core/store/network/network.selector';
 import {INetworkRootState} from '@wm-core/store/network/netwotk.reducer';
 
@@ -55,6 +59,7 @@ export class TabsPage {
       const queryParams = {
         layer,
       };
+      this._store.dispatch(wmMapHitMapChangeFeatureById({id: null}));
       this._urlHandlerSvc.changeURL(tab, queryParams);
     }
   }


### PR DESCRIPTION
- introduce EventEmitter for close event in MapDetailsComponent
- emit closeEVT in back() method to signal closure

♻️ refactor(map): update close event handling

- replace inline closeEvt handler with closeDownload() method
- improve readability and maintainability of close event logic

🔧 chore(tabs): dispatch hit map change feature action

- add wmMapHitMapChangeFeatureById action dispatch in selectTab method
- ensure proper feature reset when changing tabs
