### PR TITLE
🐛 fix(map-details): adjust animation height calculation oc:5591

### DIFF
--- a/core/src/app/pages/map/map-details/map-details.component.ts
+++ b/core/src/app/pages/map/map-details/map-details.component.ts
@@ -83,7 +83,10 @@ export class MapDetailsComponent implements AfterViewInit {
   }
 
   full(): void {
-    this.setAnimations(`${this._getCurrentHeight()}px`, `${this.height - 200}px`);
+    this.setAnimations(
+      `${this._getCurrentHeight()}px`,
+      `calc(${this.height - 200}px - env(safe-area-inset-top))`,
+    );
     this.isOpen$.next(true);
   }
 


### PR DESCRIPTION
- use safe-area-inset-top to account for device specific insets
- ensure consistent UI appearance across different devices
