### PR TITLE
refactor(map): ✨ replace ion-title with ion-label for headers

### DIFF
--- a/core/src/app/pages/map/map.page.html
+++ b/core/src/app/pages/map/map.page.html
@@ -31,17 +31,17 @@
           <ng-container
             *ngIf="(currentUgcPoiProperties$|async) as ugcPoiProperties;else titleTrack"
           >
-            <ion-title>
+            <ion-label e2e-map-details-title>
               {{ugcPoiProperties.name|wmtrans}}
               <wm-updated-at [updatedAt]="ugcPoiProperties?.updatedAt"></wm-updated-at>
-            </ion-title>
+            </ion-label>
           </ng-container>
           <ng-template #titleTrack>
             <ng-container *ngIf="currentTrack$|async as currentTrack;">
-              <ion-title>
+              <ion-label e2e-map-details-title>
                 {{currentTrack?.properties?.name|wmtrans }}
                 <wm-updated-at [updatedAt]="currentTrack?.properties?.updatedAt"></wm-updated-at
-              ></ion-title>
+              ></ion-label>
             </ng-container>
           </ng-template>
         </div>

--- a/core/src/app/pages/map/map.page.scss
+++ b/core/src/app/pages/map/map.page.scss
@@ -70,8 +70,15 @@ webmapp-map-page {
     --background-hover-opacity: 0;
   }
   .webmapp-info-header-container {
-    ion-title {
+    > ion-label {
       text-align: left;
+      font-size: unset;
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      margin: 6px;
     }
     .webmapp-pagepoi-info-header {
       width: 100%;
@@ -97,9 +104,6 @@ webmapp-map-page {
         }
       }
     }
-  }
-  ion-title {
-    font-size: unset;
   }
 
   .bottom-right,


### PR DESCRIPTION
Updated the map page HTML and corresponding SCSS and CSS files to replace the use of `ion-title` with `ion-label` for headers. This change improves the styling and layout flexibility by leveraging `ion-label` properties such as text overflow handling.

- Replaced `ion-title` with `ion-label` in `map.page.html` for better text handling.
- Updated SCSS in `map.page.scss` to adjust styles for the new `ion-label` elements.
- Modified selectors in `75.css` to target `ion-label` instead of `ion-title` and adjusted margin/padding for consistent styling.
