### PR TITLE
refactor(map): 🔄 replace ion-title with ion-label for map details oc: 5669

### DIFF
--- a/core/cypress/e2e/app_52/ec-track-details.cy.ts
+++ b/core/cypress/e2e/app_52/ec-track-details.cy.ts
@@ -56,7 +56,7 @@ describe('Show correct ec_track details', () => {
     openTrack(data.tracks.exampleOne);
     cy.wait('@getApiTrack');
 
-    cy.get('wm-map-details ion-title').should('contain', ec_track_properties.name.en);
+    cy.get('[e2e-map-details-title]').should('contain', ec_track_properties.name.en);
   });
 
   it('should show correct description on ec_track details', () => {

--- a/core/cypress/e2e/app_52/releted-poi.cy.ts
+++ b/core/cypress/e2e/app_52/releted-poi.cy.ts
@@ -11,7 +11,9 @@ describe('Track releted poi [oc:4735] [https://orchestrator.maphub.it/resources/
     openLayer(data.layers.ecTrack);
     openTrack(data.tracks.exampleTwo);
 
-    cy.get('wm-map-details').contains('ion-title', data.tracks.exampleTwo).should('exist');
+    cy.get('wm-map-details')
+      .contains('[e2e-map-details-title]', data.tracks.exampleTwo)
+      .should('exist');
     cy.get('wm-track-related-poi').should('exist');
   });
 
@@ -23,14 +25,14 @@ describe('Track releted poi [oc:4735] [https://orchestrator.maphub.it/resources/
         .contains(data.tracks.exampleTwoRelatedPoi)
         .should('exist');
 
-      cy.get('ion-title').contains(data.tracks.exampleTwo).should('exist');
+      cy.get('[e2e-map-details-title]').contains(data.tracks.exampleTwo).should('exist');
     });
   });
 
   it('Should viusalize only track detail when click on close button', () => {
     cy.get('wm-map-details').within(() => {
       cy.get('ion-fab-button.wm-close-btn').click();
-      cy.get('ion-title').contains(data.tracks.exampleTwo).should('exist');
+      cy.get('[e2e-map-details-title]').contains(data.tracks.exampleTwo).should('exist');
       cy.get('.webmapp-pagepoi-info-header-title').should('not.exist');
     });
   });

--- a/core/cypress/e2e/app_52/tracks-edge.cy.ts
+++ b/core/cypress/e2e/app_52/tracks-edge.cy.ts
@@ -51,7 +51,7 @@ function iterateUntilEdgeButtonDoesNotExist(selectedTrackId, direction) {
       lastTrackId = edges[selectedTrackId][edgeKey][0];
       const edgeTrack = ecTracks.find(track => track.id === lastTrackId);
       clickFunction();
-      cy.get('wm-map-details ion-title').should('contain', edgeTrack.name);
+      cy.get('[e2e-map-details-title]').should('contain', edgeTrack.name);
       iterateUntilEdgeButtonDoesNotExist(lastTrackId, direction);
     }
   });

--- a/core/src/app/pages/map/map-details/map-details.component.scss
+++ b/core/src/app/pages/map/map-details/map-details.component.scss
@@ -5,7 +5,7 @@ wm-map-details {
     top: env(safe-area-inset-top, 30px); // for ios 11.2 and onwards
   }
   .wm-drag {
-    width: 100%;
+    width: calc(100% - 20px);
     height: auto;
     text-align: center;
     display: block;

--- a/core/src/app/pages/map/map.page.html
+++ b/core/src/app/pages/map/map.page.html
@@ -40,17 +40,17 @@
           <ng-container
             *ngIf="(currentUgcPoiProperties$|async) as ugcPoiProperties;else titleTrack"
           >
-            <ion-title>
+            <ion-label e2e-map-details-title>
               {{ugcPoiProperties.name|wmtrans}}
               <wm-updated-at [updatedAt]="ugcPoiProperties?.updatedAt"></wm-updated-at>
-            </ion-title>
+            </ion-label>
           </ng-container>
           <ng-template #titleTrack>
             <ng-container *ngIf="currentTrack$|async as currentTrack;">
-              <ion-title>
+              <ion-label e2e-map-details-title>
                 {{currentTrack?.properties?.name|wmtrans }}
                 <wm-updated-at [updatedAt]="currentTrack?.properties?.updatedAt"></wm-updated-at
-              ></ion-title>
+              ></ion-label>
             </ng-container>
           </ng-template>
         </div>

--- a/core/src/app/pages/map/map.page.scss
+++ b/core/src/app/pages/map/map.page.scss
@@ -70,8 +70,15 @@ webmapp-map-page {
     --background-hover-opacity: 0;
   }
   .webmapp-info-header-container {
-    ion-title {
+    > ion-label {
       text-align: left;
+      font-size: unset;
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      margin: 6px;
     }
     .webmapp-pagepoi-info-header {
       width: 100%;


### PR DESCRIPTION
* refactor(map): 🔄 replace ion-title with ion-label for map details

Replaced `ion-title` with `ion-label` for both UGC POI properties and track details in the map page HTML. Updated corresponding SCSS to style the `ion-label`, ensuring text alignment, multi-line display with ellipsis, and consistent margins. This change improves UI consistency and fixes layout issues related to text overflow.

* refactor(e2e): ♻️ update selector for map details title

Replaced the `ion-title` selector with a more specific `[e2e-map-details-title]` selector across multiple test files to improve robustness and consistency in element selection. This change affects the following test files:

- `ec-track-details.cy.ts`
- `releted-poi.cy.ts`
- `tracks-edge.cy.ts`
- `ugc-tracks-map-click.cy.ts`

The update ensures that the tests accurately target the intended elements, reducing the risk of false positives or negatives due to selector mismatches.

* style(theme): 💄 update styles for wm-map-details headers

Updated the CSS selectors for `wm-map-details` headers to use `ion-label` instead of `ion-title`. This change includes adjustments to the margin and padding for the header containers to improve visual alignment and consistency.

- Replaced `ion-title` with `ion-label` in relevant CSS rules.
- Adjusted the margin and padding for `.webmapp-info-header-container > ion-label`.
- Ensured consistent styling for `wm-map-details` and POI properties.

style(map): 💄 adjust drag element width to account for padding

Reduced the width of the `.wm-drag` element to `calc(100% - 20px)` to ensure proper padding and alignment within the map details component. This change improves the visual layout by preventing overflow and maintaining consistent spacing.
