### PR TITLE
chore(map, register): ✨ add center position feature oc:5246

### DIFF
--- a/core/src/app/pages/map/map.page.html
+++ b/core/src/app/pages/map/map.page.html
@@ -158,7 +158,7 @@
           >
           </wm-btn-orientation>
           <ion-fab-button (click)="geoboxMap.navigation()">
-            <ion-icon name="navigate-outline" color="dark"></ion-icon>
+            <ion-icon name="navigate-outline"></ion-icon>
           </ion-fab-button>
           <wm-btn-center-position
             *ngIf="false"

--- a/core/src/app/pages/register/register.page.html
+++ b/core/src/app/pages/register/register.page.html
@@ -26,6 +26,7 @@
     wmMapPosition
     [wmMapPositioncurrentLocation]="currentPosition$|async"
     [wmMapPositionfocus]="focusPosition$|async"
+    [wmMapPositionCenter]="centerPositionEvt$|async"
     wmMapTrack
     [track]="currentTrack$|async"
     [wmMapTrackColor]="trackColor$|async"
@@ -137,6 +138,9 @@
       vertical="bottom"
       horizontal="end"
     >
+      <ion-fab-button (click)="centerPositionEvt$.next((!centerPositionEvt$.value)||false)">
+        <ion-icon name="navigate-outline" color="primary"></ion-icon>
+      </ion-fab-button>
       <wm-btn-orientation
         [degrees]="wmapregister.mapDegrees"
         (click)="wmapregister.orientNorth()"

--- a/core/src/app/pages/register/register.page.scss
+++ b/core/src/app/pages/register/register.page.scss
@@ -152,9 +152,14 @@
   left: 10px;
 }
 
-.wm-fab-container{
+.wm-fab-container {
   bottom: 33px;
-  ion-fab-button{
+  > ion-fab-button {
+    height: 42px;
+    width: 42px;
+    margin: 8px;
+  }
+  ion-fab-button {
     --background: var(--wm-color-light);
   }
 }

--- a/core/src/app/pages/register/register.page.ts
+++ b/core/src/app/pages/register/register.page.ts
@@ -40,6 +40,7 @@ export class RegisterPage implements OnInit, OnDestroy, AfterViewInit {
 
   actualSpeed: number = 0;
   averageSpeed: number = 0;
+  centerPositionEvt$: BehaviorSubject<boolean> = new BehaviorSubject<boolean | null>(null);
   confMap$: Observable<any> = this._store.select(confMAP);
   confTRACKFORMS$: Observable<any[]> = this._store.select(confTRACKFORMS);
   currentPosition$: Observable<Location> = this._geolocationSvc.onLocationChange;


### PR DESCRIPTION
- Removed the dark color from the navigation icon in `map.page.html` to use the default color.
- Added a new input `[wmMapPositionCenter]` in `register.page.html` to bind the `centerPositionEvt$`.
- Introduced a new center position button in the register page's fab container for centering the map.
- Updated the SCSS for the fab button in `register.page.scss` to control the size and margin.
- Added `centerPositionEvt$` BehaviorSubject to `register.page.ts` to manage the center position state.
