### PR TITLE
chore(core): ✨ add base form visibility component oc:5577

### DIFF
--- a/core/src/app/components/base-form-visibility.component.ts/base-form-visibility.component.ts
+++ b/core/src/app/components/base-form-visibility.component.ts/base-form-visibility.component.ts
@@ -1,0 +1,76 @@
+import {ChangeDetectorRef, ElementRef} from '@angular/core';
+import {IonContent} from '@ionic/angular';
+import {UntypedFormGroup} from '@angular/forms';
+import {BehaviorSubject, from} from 'rxjs';
+import {take, tap} from 'rxjs/operators';
+
+export abstract class BaseFormVisibilityComponent {
+  abstract ionContent: IonContent;
+  abstract formContainer: ElementRef;
+
+  formGroup: UntypedFormGroup;
+  seeAllForm$: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
+
+  constructor(protected _cdr: ChangeDetectorRef) {}
+
+  private _checkFormVisibility = (): void => {
+    if (!this.ionContent || !this.formContainer) {
+      return;
+    }
+
+    from(this.ionContent.getScrollElement())
+      .pipe(
+        take(1),
+        tap(scrollElement => {
+          const contentHeight = scrollElement?.clientHeight;
+          const scrollTop = scrollElement?.scrollTop;
+          const scrollHeight = scrollElement?.scrollHeight;
+
+          const formElement = (this.formContainer as any)?.el;
+          const formRect = formElement?.getBoundingClientRect();
+          const contentRect = scrollElement.getBoundingClientRect();
+
+          const isFormFullyVisible =
+            formRect?.top >= contentRect?.top && formRect?.bottom <= contentRect?.bottom;
+          const isAtBottom = scrollTop + contentHeight >= scrollHeight - 1;
+          const shouldSeeAllForm = isFormFullyVisible || isAtBottom;
+
+          if (shouldSeeAllForm) {
+            scrollElement.removeEventListener('scroll', this._checkFormVisibility);
+          }
+          this.seeAllForm$.next(shouldSeeAllForm);
+          this._cdr.detectChanges();
+        }),
+      )
+      .subscribe();
+  };
+
+  private _setupScrollListener(): void {
+    if (!this.ionContent) {
+      return;
+    }
+
+    from(this.ionContent.getScrollElement())
+      .pipe(
+        take(1),
+        tap(scrollElement => {
+          scrollElement.addEventListener('scroll', this._checkFormVisibility);
+        }),
+      )
+      .subscribe();
+  }
+
+  private _initializeFormVisibility(): void {
+    // Usato perchè il cambiamento della form non è immediato, attendo che la form sia
+    // renderizzata nel DOM
+    requestAnimationFrame(() => {
+      this._checkFormVisibility();
+      this._setupScrollListener();
+    });
+  }
+
+  setFormGroup(formGroup: UntypedFormGroup): void {
+    this.formGroup = formGroup;
+    this._initializeFormVisibility();
+  }
+}

--- a/core/src/app/pages/register/modal-save/modal-save.component.html
+++ b/core/src/app/pages/register/modal-save/modal-save.component.html
@@ -20,8 +20,8 @@
   </ion-toolbar>
 </ion-header>
 <ion-content>
-  <ion-list>
-    <wm-form [confPOIFORMS]="acquisitionFORM$|async" (formGroupEvt)="fg = $event">
+  <ion-list #formContainer>
+    <wm-form [confPOIFORMS]="acquisitionFORM$|async" (formGroupEvt)="setFormGroup($event)">
       <webmapp-form-field
         [icon]="'webmapp-icon-camera'"
         [iconColor]="'secondary'"
@@ -42,7 +42,7 @@
   <ion-button
     class="webmapp-register-modalsave-savebtn"
     (click)="save()"
-    [disabled]="fg == null || (fg!=null && fg.invalid)"
+    [disabled]="formGroup == null || (formGroup!=null && formGroup.invalid) || !(seeAllForm$|async)"
   >
     {{ "pages.register.modalsave.savebtn" | wmtrans }}</ion-button
   >

--- a/core/src/app/pages/waypoint/modal-waypoint-save/modal-waypoint-save.component.html
+++ b/core/src/app/pages/waypoint/modal-waypoint-save/modal-waypoint-save.component.html
@@ -16,13 +16,13 @@
     [wmMapGeojson]="position"
   ></wm-map>
 
-  <ion-list class="webmapp-modalwaypoint-itemlist">
+  <ion-list class="webmapp-modalwaypoint-itemlist" #formContainer>
     <ion-item class="webmapp-formfield-item">
       <ion-label class="webmapp-formfield-label" position="stacked">
         {{  nominatim?.display_name  | wmtrans }}
       </ion-label>
     </ion-item>
-    <wm-form [confPOIFORMS]="acquisitionFORM$|async" (formGroupEvt)="fg = $event">
+    <wm-form [confPOIFORMS]="acquisitionFORM$|async" (formGroupEvt)="setFormGroup($event)">
       <webmapp-form-field
         [icon]="'webmapp-icon-camera'"
         [iconColor]="'secondary'"
@@ -45,7 +45,7 @@
     <ion-button
       class="webmapp-modalwaypoint-savebtn"
       (click)="save()"
-      [disabled]="fg ==null || (fg!=null &&fg.invalid)"
+      [disabled]="formGroup == null || (formGroup != null &&formGroup.invalid) || !(seeAllForm$|async)"
     >
       {{ "pages.waypoint.modalsave.save" | wmtrans }}
     </ion-button>


### PR DESCRIPTION
Introduce `BaseFormVisibilityComponent` to manage form visibility within Ionic content. This component simplifies tracking whether a form is visible within the viewport by using a scroll listener. It updates the form's visibility state using a `BehaviorSubject`.

The `ModalSaveComponent` and `ModalWaypointSaveComponent` now extend this base component, leveraging its functionality to ensure forms are fully visible before enabling save actions. This involves:

- Adding `ionContent` and `formContainer` ViewChildren for scroll and form elements.
- Implementing form visibility logic within the base component.
- Replacing form group assignments and checks with the new form group setter method.

These changes enhance the user interaction by preventing form submissions when the form is not fully visible, ensuring all required fields are completed before proceeding.
