### PR TITLE
refactor(core): ♻️ replace requestAnimationFrame with interval for form visibility check oc:5577

### DIFF
--- a/core/src/app/components/base-save.component.ts/base-save.component.ts
+++ b/core/src/app/components/base-save.component.ts/base-save.component.ts
@@ -145,10 +145,15 @@ export abstract class BaseSaveComponent {
   private _initializeFormVisibility(): void {
     // Used because the form change is not immediate, I wait for the form to be
     // rendered in the DOM
-    requestAnimationFrame(() => {
-      this._checkFormVisibility();
-      this._setupScrollListener();
-    });
+    const interval = setInterval(() => {
+      const formElement = (this.formContainer as any)?.el;
+      const formHeight = formElement?.scrollHeight;
+      if (formHeight && formHeight > 0) {
+        clearInterval(interval);
+        this._checkFormVisibility();
+        this._setupScrollListener();
+      }
+    }, 50);
   }
 
   /**


### PR DESCRIPTION
The `_initializeFormVisibility` method now uses a `setInterval` to repeatedly check the form's height until it is rendered, replacing the previous `requestAnimationFrame`. This change ensures the form's visibility checks and scroll listener setup occur only after the form is fully rendered in the DOM. The interval is cleared once the form height is determined to be greater than zero, indicating successful rendering.
