### PR TITLE
chore(map): 🌍 implement tiles download feature oc:5578

### DIFF
--- a/core/cypress/e2e/app_52/tails-download.cy.ts
+++ b/core/cypress/e2e/app_52/tails-download.cy.ts
@@ -1,0 +1,34 @@
+import {clearTestState, goMap, mapReadyTimeout} from 'cypress/utils/test-utils';
+
+describe('Tiles download', () => {
+  before(() => {
+    clearTestState();
+    cy.visit('/');
+  });
+
+  it('should see target area overlay', () => {
+    goMap();
+    cy.get('body', {timeout: mapReadyTimeout}).should('have.attr', 'e2e-map-ready', 'true');
+    cy.get('[e2e-map-tiles-download-button]').click();
+    cy.get('[e2e-map-tiles-target-area-overlay]').should('exist');
+  });
+
+  it('should download tiles', () => {
+    cy.get('.wm-map-tiles-download-button ion-button').should('be.visible').click();
+    cy.get('wm-download').should('be.visible');
+
+    cy.get('.webmapp-downloadpanel-button').should('be.visible').click();
+    cy.get('.webmapp-downloadpanel-title', {timeout: 30000})
+      .should('be.visible')
+      .should('have.text', 'Download completed');
+
+    cy.get('.webmapp-downloadpanel-button').should('be.visible').click();
+  });
+
+  it('should see bounding box delete button', () => {
+    cy.get('body').click('center'); //click sulla feature del bounding box
+    cy.get('.wm-map-delete-button').should('be.visible').click();
+    cy.get('.alert-button-group button').eq(1).click();
+    cy.get('.wm-map-delete-button').should('not.exist');
+  });
+});

--- a/core/cypress/e2e/app_52/tiles-download.cy.ts
+++ b/core/cypress/e2e/app_52/tiles-download.cy.ts
@@ -1,6 +1,6 @@
 import {clearTestState, goMap, mapReadyTimeout} from 'cypress/utils/test-utils';
 
-describe('Tiles download', () => {
+describe('Tiles download by bounding box', () => {
   before(() => {
     clearTestState();
     cy.visit('/');
@@ -10,6 +10,11 @@ describe('Tiles download', () => {
     goMap();
     cy.get('body', {timeout: mapReadyTimeout}).should('have.attr', 'e2e-map-ready', 'true');
     cy.get('[e2e-map-tiles-download-button]').click();
+    cy.wait(400); // wait for zoom animation to finish
+    for (let i = 0; i < 5; i++) {
+      cy.get('.ol-zoom-in').should('be.visible').click();
+      cy.wait(100); // wait for zoom animation to finish
+    }
     cy.get('[e2e-map-tiles-target-area-overlay]').should('exist');
   });
 
@@ -25,10 +30,10 @@ describe('Tiles download', () => {
     cy.get('.webmapp-downloadpanel-button').should('be.visible').click();
   });
 
-  it('should see bounding box delete button', () => {
+  it('should see bounding box delete button and delete it', () => {
     cy.get('body').click('center'); //click sulla feature del bounding box
-    cy.get('.wm-map-delete-button').should('be.visible').click();
+    cy.get('.wm-map-delete-bounding-box-button').should('be.visible').click();
     cy.get('.alert-button-group button').eq(1).click();
-    cy.get('.wm-map-delete-button').should('not.exist');
+    cy.get('.wm-map-delete-bounding-box-button').should('not.exist');
   });
 });

--- a/core/cypress/e2e/app_52/wm-form.cy.ts
+++ b/core/cypress/e2e/app_52/wm-form.cy.ts
@@ -189,6 +189,7 @@ describe('Test wm-form field', () => {
       });
 
     // Inserisci un testo tutto in minuscolo
+    cy.wait(300);
     const testoMinuscolo = 'testo di esempio';
     cy.get('@titleInput').type(testoMinuscolo);
 

--- a/core/cypress/utils/test-utils.ts
+++ b/core/cypress/utils/test-utils.ts
@@ -1,5 +1,6 @@
 import {environment} from 'src/environments/environment';
 import {clearUgcSynchronizedData, clearUgcDeviceData, removeAuth} from '@wm-core/utils/localForage';
+import {clearMapCoreData} from '@map-core/utils';
 
 /**
  * Clears the test state.
@@ -11,6 +12,7 @@ export function clearTestState(): void {
   cy.clearCookies();
   clearUgcSynchronizedData();
   clearUgcDeviceData();
+  clearMapCoreData();
   removeAuth();
 }
 

--- a/core/src/app/app.component.ts
+++ b/core/src/app/app.component.ts
@@ -26,6 +26,7 @@ import {INetworkRootState} from '@wm-core/store/network/netwotk.reducer';
 import {startNetworkMonitoring} from '@wm-core/store/network/network.actions';
 import {syncUgc} from '@wm-core/store/features/ugc/ugc.actions';
 import {loadHitmapFeatures} from '@wm-core/store/user-activity/user-activity.action';
+import {loadBoundingBoxes} from '@map-core/store/map-core.actions';
 
 @Component({
   selector: 'webmapp-app-root',
@@ -58,6 +59,7 @@ export class AppComponent {
     this._store.dispatch(ecTracks({init: true}));
     this._store.dispatch(loadEcPois());
     this._store.dispatch(syncUgc());
+    this._store.dispatch(loadBoundingBoxes());
     this.confTHEMEVariables$.pipe(take(2)).subscribe(css => this._setGlobalCSS(css));
     this._storeNetwork.dispatch(startNetworkMonitoring());
 

--- a/core/src/app/pages/map/download-panel/download-panel.component.html
+++ b/core/src/app/pages/map/download-panel/download-panel.component.html
@@ -13,7 +13,9 @@
     class="webmapp-downloadpanel-status"
     >{{track?.properties.name | wmtrans}}</ion-label
   >
-  <ion-label *ngIf="isInit || isDownloading" class="webmapp-downloadpanel-title"
+  <ion-label
+    *ngIf="(isInit || isDownloading) && track?.properties.name"
+    class="webmapp-downloadpanel-title"
     >{{track?.properties.name | wmtrans}}
   </ion-label>
   <ion-label

--- a/core/src/app/pages/map/download-panel/download-panel.component.scss
+++ b/core/src/app/pages/map/download-panel/download-panel.component.scss
@@ -3,14 +3,14 @@ wm-download-panel {
     width: 100%;
     height: auto;
     max-height: 80vh;
-    overflow-y: scroll;
     padding: 10px 0;
   }
 
   .webmapp-downloadpanel-status {
-    font-size: var(--wm-font-sm);
-    color: var(--wm-color-darkgrey);
+    font-size: var(--wm-font-lg);
+    color: var(--wm-color-dark);
     display: block;
+    padding: 6px 0;
   }
 
   .webmapp-downloadpanel-title {
@@ -18,7 +18,7 @@ wm-download-panel {
     font-size: var(--wm-font-lg);
     color: var(--wm-color-dark);
     display: block;
-    padding: 15px 0;
+    padding: 6px 0;
   }
 
   .webmapp-downloadpanel-element-title {

--- a/core/src/app/pages/map/download-panel/download-panel.component.ts
+++ b/core/src/app/pages/map/download-panel/download-panel.component.ts
@@ -12,7 +12,7 @@ import {
 
 import {DownloadStatus} from 'src/app/types/download';
 import {downloadPanelStatus} from 'src/app/types/downloadpanel.enum';
-import {LineString} from 'geojson';
+import {LineString, MultiPolygon} from 'geojson';
 import {downloadEcTrack} from '@wm-core/utils/localForage';
 import {WmFeature} from '@wm-types/feature';
 import {Store} from '@ngrx/store';
@@ -41,7 +41,7 @@ export class WmDownloadPanelComponent implements OnChanges {
   @Input() overlayUrls: {[featureName: string]: string};
   @Input() overlayGeometry: any;
   @Input() overlayXYZ: string = `https://api.webmapp.it/tiles`;
-  @Input() boundingBox: any;
+  @Input() boundingBox: WmFeature<MultiPolygon>;
   @Output('changeStatus') changeStatus: EventEmitter<downloadPanelStatus> =
     new EventEmitter<downloadPanelStatus>();
   @Output('closeDownload') closeDownload: EventEmitter<any> = new EventEmitter<any>();

--- a/core/src/app/pages/map/download/download.component.html
+++ b/core/src/app/pages/map/download/download.component.html
@@ -12,8 +12,10 @@
       [overlayUrls]="overlayUrls"
       [overlayGeometry]="overlayGeometry"
       [overlayXYZ]="overlayXYZ"
+      [boundingBox]="boundingBox"
       (changeStatus)="downloadStatus($event)"
       (exit)="endDownload()"
+      (closeDownload)="closeEvt.emit()"
     ></wm-download-panel>
   </div>
 </div>

--- a/core/src/app/pages/map/download/download.component.scss
+++ b/core/src/app/pages/map/download/download.component.scss
@@ -1,5 +1,6 @@
 wm-download {
   position: relative;
+  z-index: 1001;
   .webmapp-pageroute-downloadpanel-container {
     background-color: white;
     position: relative;

--- a/core/src/app/pages/map/download/download.component.ts
+++ b/core/src/app/pages/map/download/download.component.ts
@@ -26,6 +26,7 @@ export class WmDownloadComponent implements OnInit {
   @Input() overlayUrls: {[featureName: string]: string};
   @Input() overlayGeometry: any;
   @Input() overlayXYZ: string;
+  @Input() boundingBox: any;
   @Output() closeEvt: EventEmitter<void> = new EventEmitter<void>();
   @Output() goToEvt: EventEmitter<string> = new EventEmitter<string>();
 

--- a/core/src/app/pages/map/download/download.component.ts
+++ b/core/src/app/pages/map/download/download.component.ts
@@ -11,7 +11,7 @@ import {AlertController} from '@ionic/angular';
 import {LangService} from '@wm-core/localization/lang.service';
 import {downloadPanelStatus} from '@wm-core/types/downloadpanel.enum';
 import {WmFeature} from '@wm-types/feature';
-import {LineString} from 'geojson';
+import {LineString, MultiPolygon} from 'geojson';
 @Component({
   selector: 'wm-download',
   templateUrl: './download.component.html',
@@ -26,7 +26,7 @@ export class WmDownloadComponent implements OnInit {
   @Input() overlayUrls: {[featureName: string]: string};
   @Input() overlayGeometry: any;
   @Input() overlayXYZ: string;
-  @Input() boundingBox: any;
+  @Input() boundingBox: WmFeature<MultiPolygon>;
   @Output() closeEvt: EventEmitter<void> = new EventEmitter<void>();
   @Output() goToEvt: EventEmitter<string> = new EventEmitter<string>();
 

--- a/core/src/app/pages/map/map.page.html
+++ b/core/src/app/pages/map/map.page.html
@@ -141,6 +141,11 @@
           </ion-fab-button>
         </ion-fab>
       </ng-container>
+      <ion-fab slot="fixed" vertical="top" horizontal="start">
+        <ion-fab-button (click)="toggleTilesDownload()" e2e-map-tiles-download-button>
+          <ion-icon name="scan-outline"></ion-icon>
+        </ion-fab-button>
+      </ion-fab>
       <ion-fab
         #fab2
         slot="fixed"
@@ -172,7 +177,7 @@
         vertical="top"
         horizontal="start"
         #fab3
-        *ngIf="isTrackRecordingEnable$|async"
+        *ngIf="(isTrackRecordingEnable$|async) && !(enableTilesDownload$|async)"
         (click)="fab2?.close();fab1?.close()"
       >
         <ion-fab-button size="small" class="wm-btn-register-fab">
@@ -201,11 +206,18 @@
       [overlayUrls]="overlayFeatureCollections$|async"
       [overlayXYZ]="'https://tiles.webmapp.it/carg'"
       [overlayGeometry]="hitMapGeometry$|async"
+      [boundingBox]="wmMapTilesBoundingBox$|async"
       (closeEvt)="closeDownload()"
       (goToEvt)="goToPage($event)"
     ></wm-download>
 
     <wm-track-recorder *ngIf="enableTrackRecorderPanel$|async"></wm-track-recorder>
     <wm-poi-recorder *ngIf="enablePoiRecorderPanel$|async"></wm-poi-recorder>
+
+    <div class="wm-map-tiles-download-button" *ngIf="enableTilesDownload$|async">
+      <ion-button (click)="downloadTiles()" [disabled]="disableTilesDownloadButton$|async"
+        >Download Tiles</ion-button
+      >
+    </div>
   </wm-geobox-map>
 </ion-content>

--- a/core/src/app/pages/map/map.page.html
+++ b/core/src/app/pages/map/map.page.html
@@ -216,7 +216,7 @@
 
     <div class="wm-map-tiles-download-button" *ngIf="enableTilesDownload$|async">
       <ion-button (click)="downloadTiles()" [disabled]="disableTilesDownloadButton$|async"
-        >Download Tiles</ion-button
+        >{{"Download Tiles"|wmtrans}}</ion-button
       >
     </div>
   </wm-geobox-map>

--- a/core/src/app/pages/map/map.page.scss
+++ b/core/src/app/pages/map/map.page.scss
@@ -108,6 +108,21 @@ webmapp-map-page {
     }
   }
 
+  .wm-map-tiles-download-button {
+    position: absolute;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    bottom: 40px;
+    width: 100%;
+    z-index: 1000;
+    transition: bottom 0.4s ease-in-out;
+
+    ion-button {
+      --border-radius: 20px;
+    }
+  }
+
   .bottom-right,
   .ol-zoom {
     opacity: 1;
@@ -119,12 +134,18 @@ webmapp-map-page {
         bottom: 110px;
       }
     }
+    .wm-map-tiles-download-button {
+      bottom: 110px;
+    }
   }
   .open {
     wm-track-recorder {
       .wm-recorder-btnrec-container {
         bottom: 357px;
       }
+    }
+    .wm-map-tiles-download-button {
+      bottom: 357px;
     }
   }
   .full {
@@ -134,6 +155,9 @@ webmapp-map-page {
       pointer-events: none;
     }
     .wm-recorder-btnrec-container {
+      bottom: calc(100vh - 170px);
+    }
+    .wm-map-tiles-download-button {
       bottom: calc(100vh - 170px);
     }
   }

--- a/core/src/environments/environment.ts
+++ b/core/src/environments/environment.ts
@@ -7,7 +7,7 @@ import {Environment, shards, redirects} from '@wm-types/environment';
 export const environment: Environment = {
   production: false,
   debug: true,
-  appId: 3,
+  appId: 52,
   shardName: 'geohub',
   shards,
   redirects,


### PR DESCRIPTION
Added the ability to download map tiles through a new download panel. This includes:
- Cypress end-to-end tests for tiles download.
- Integration of bounding boxes for tile selection.
- Update of UI components to support tiles downloading.
- Adjustment of styles for better display of download elements.
- Store actions and observables to manage download state and interactions.

The changes enhance the map page functionality by allowing users to download specific map tiles, improving offline usage and user experience.
