### PR TITLE
chore(app): ✨ load icons on app initialization oc:6323

### DIFF
--- a/core/src/app/app.component.ts
+++ b/core/src/app/app.component.ts
@@ -27,6 +27,7 @@ import {startNetworkMonitoring} from '@wm-core/store/network/network.actions';
 import {syncUgc} from '@wm-core/store/features/ugc/ugc.actions';
 import {loadHitmapFeatures} from '@wm-core/store/user-activity/user-activity.action';
 import {loadBoundingBoxes} from '@map-core/store/map-core.actions';
+import {loadIcons} from '@wm-core/store/icons/icons.actions';
 
 @Component({
   selector: 'webmapp-app-root',
@@ -56,6 +57,7 @@ export class AppComponent {
   ) {
     this._store.dispatch(loadAuths());
     this._store.dispatch(loadConf());
+    this._store.dispatch(loadIcons());
     this._store.dispatch(ecTracks({init: true}));
     this._store.dispatch(loadEcPois());
     this._store.dispatch(syncUgc());

--- a/core/src/app/components/poi-properties/poi-properties.component.html
+++ b/core/src/app/components/poi-properties/poi-properties.component.html
@@ -1,3 +1,4 @@
+<!-- TODO: unire ugc-properties con poi-properties? -->
 <ng-container *ngIf="currentPoiProperties$|async as properties">
   <div class="wm-poi-properties-body">
     <ion-label *ngIf="distanceFromCurrentPoi$|async as distanceFromCurrentPoi">
@@ -24,6 +25,15 @@
       *ngIf="properties?.taxonomy?.poi_types as poiTypes"
       [poiTypes]="poiTypes"
     ></wm-poi-types-badges>
+    <ng-container *ngIf="properties?.form">
+      <wm-form
+        class="wm-ugc-poi-form-readonly"
+        [disabled]="true"
+        [confPOIFORMS]="confPOIFORMS$|async"
+        [init]="properties?.form"
+        (formGroupEvt)="formGroup = $event"
+      ></wm-form>
+    </ng-container>
     <ng-container *ngIf="properties?.info as info">
       <div class="wm-poi-properties-info" [innerHTML]="sanitize(info|wmtrans)"></div>
     </ng-container>

--- a/core/src/app/components/poi-properties/poi-properties.component.ts
+++ b/core/src/app/components/poi-properties/poi-properties.component.ts
@@ -1,13 +1,14 @@
 import {Component, ChangeDetectionStrategy, Input, ViewEncapsulation} from '@angular/core';
 import {GeolocationService} from '@wm-core/services/geolocation.service';
 import {Store} from '@ngrx/store';
-import {BehaviorSubject} from 'rxjs';
+import {BehaviorSubject, Observable} from 'rxjs';
 import {currentPoiProperties} from '@wm-core/store/features/ec/ec.selector';
 import {tap} from 'rxjs/internal/operators/tap';
 import {poi} from '@wm-core/store/features/features.selector';
 import {switchMap} from 'rxjs/operators';
 import {DomSanitizer} from '@angular/platform-browser';
-import {confOPTIONSShowEmbeddedHtml} from '@wm-core/store/conf/conf.selector';
+import {confOPTIONSShowEmbeddedHtml, confPOIFORMS} from '@wm-core/store/conf/conf.selector';
+import {UntypedFormGroup} from '@angular/forms';
 @Component({
   selector: 'wm-poi-properties',
   templateUrl: './poi-properties.component.html',
@@ -17,6 +18,8 @@ import {confOPTIONSShowEmbeddedHtml} from '@wm-core/store/conf/conf.selector';
 })
 export class PoiPropertiesComponent {
   confOPTIONSShowEmbeddedHtml$ = this._store.select(confOPTIONSShowEmbeddedHtml);
+  confPOIFORMS$: Observable<any[]> = this._store.select(confPOIFORMS);
+  formGroup: UntypedFormGroup;
   currentPoiProperties$ = this._store.select(currentPoiProperties).pipe(
     tap(properties => {
       this.showTechnicalDetails$.next(properties?.ele || properties?.address);


### PR DESCRIPTION
Added the dispatch of `loadIcons()` action in the `AppComponent` constructor to ensure icons are loaded during the app's initialization phase.

feat(poi-properties): ✨ integrate readonly form in poi properties

Added a readonly form in the `poi-properties.component.html` to display POI form data if available. Updated the component to include necessary selectors and form group management.

Added a TODO in the HTML to consider merging `ugc-properties` with `poi-properties`.
