### PR TITLE
feat(oc:8105): validate posthog.json before gulp build

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,3 +109,16 @@ Required for all functions and methods (enforced by ESLint).
 ## Technology Stack
 
 Angular 20 · Ionic 8 · Capacitor 7 · NgRx 20 · OpenLayers 7 · @ngx-translate · Swiper 12 · PostHog · Cypress 14
+
+## Feature disponibili
+
+| Feature | Ticket | Moduli toccati | Note |
+|---|---|---|---|
+| Validazione posthog.json prima della build | oc:8105 | `gulpfile.js` | Valida esistenza, JSON valido e chiavi POSTHOG_KEY/POSTHOG_HOST non vuote; copia il file nell'istanza dopo create() |
+
+## Decisioni architetturali
+
+### Validazione posthog.json (oc:8105)
+- `validatePosthogConfig()` usa `throw new Error()` invece di `process.exit(1)`: il throw dentro un Promise executor viene catturato automaticamente da Node come rejection, permettendo il teardown di Gulp
+- `fs.copyFileSync` in `build()` è wrappato in try/catch con `reject()` per evitare che eccezioni sincrone dentro `.then()` diventino unhandled Promise rejection con la Promise esterna bloccata in pending
+- `instances/posthog.json` è gitignored — in CI va creato esplicitamente via secrets prima di invocare gulp

--- a/docs/features/8105-gulp-validazione-posthog-json/notes.md
+++ b/docs/features/8105-gulp-validazione-posthog-json/notes.md
@@ -1,0 +1,25 @@
+> Ticket: oc:8105
+
+# Notes — Gulp: validazione posthog.json prima della build
+
+## Deviazioni dal piano
+
+- `process.exit(1)` sostituito con `throw new Error()` su indicazione della code review (wm-review-ticket): il `throw` dentro un Promise executor viene catturato automaticamente da Node e convertito in rejection pulita, permettendo il teardown di Gulp. Il piano originale usava `process.exit(1)` per semplicità.
+- `fs.existsSync` rimosso: la code review ha evidenziato il pattern TOCTOU (Time-Of-Check Time-Of-Use). L'unico try/catch con `err.code === 'ENOENT'` è più corretto e più conciso.
+- `fs.copyFileSync` wrappato in try/catch con `reject()`: senza il try/catch, un'eccezione nella copia avrebbe causato una unhandled Promise rejection con la Promise esterna di `build()` bloccata in pending.
+- Aggiunto check `typeof val !== 'string'`: se una chiave nel JSON è un numero o null, `.trim()` avrebbe lanciato TypeError non gestito.
+- Aggiunta costante `ABORTING_BANNER` per evitare la ripetizione della stringa "Aborting" 3 volte.
+
+## Bug trovati
+
+- Nessun bug pre-esistente trovato nell'area toccata.
+
+## Decisioni
+
+- La funzione `validatePosthogConfig()` è sincrona e può lanciare — questo è documentato nella funzione stessa tramite il comportamento del throw. Non è stata convertita a Promise per mantenere la semplicità e perché il Promise executor la cattura automaticamente.
+- `ABORTING_BANNER` è definita come costante a livello di modulo (non dentro la funzione) per coerenza con le altre costanti del gulpfile (es. `CONSOLE_COLORS`, `APIGEOHUB`).
+
+## Follow-up
+
+- **CI/CD**: prima del merge, verificare che il secret `instances/posthog.json` sia configurato in GitHub Actions. Il file è gitignored e non viene creato automaticamente — senza di esso tutte le build CI falliranno con l'errore esplicito del gulp.
+- **Rollback di emergenza**: se serve una build urgente durante una rotazione di credenziali PostHog, creare temporaneamente `instances/posthog.json` con i valori precedenti.

--- a/docs/features/8105-gulp-validazione-posthog-json/overview.md
+++ b/docs/features/8105-gulp-validazione-posthog-json/overview.md
@@ -1,0 +1,38 @@
+> Ticket: oc:8105
+
+# Gulp: validazione posthog.json prima della build
+
+## Cosa cambia
+
+Il gulpfile aggiunge, all'inizio della funzione `build()`, una validazione esplicita di `instances/posthog.json`. Se il file non esiste o una delle chiavi obbligatorie (`POSTHOG_KEY`, `POSTHOG_HOST`) è mancante o vuota (dopo `.trim()`), la build si interrompe subito con un messaggio guidato su console. Dopo la fase `create()`, il file viene copiato in `instances/<instanceName>/posthog.json` per renderlo disponibile al compilatore TypeScript.
+
+## Perché
+
+L'app importa `posthog.json` in `app.module.ts` (`import posthogConfig from '../../../posthog.json'`). Se i valori sono assenti, PostHog viene inizializzato con credenziali vuote e l'analytics smette di funzionare silenziosamente in produzione. Attualmente il gulp non valida il file e l'errore emerge solo a compile time con un messaggio criptico.
+
+## Requisiti
+
+- [ ] Se `instances/posthog.json` non esiste, la build fallisce immediatamente con errore esplicito
+- [ ] Se il file esiste ma il JSON non è valido (parsing error), la build fallisce con messaggio che indica il percorso del file e il dettaglio dell'errore di parsing
+- [ ] Se `POSTHOG_KEY` è mancante o vuota (dopo `.trim()`), la build fallisce con messaggio guidato che indica il file da correggere
+- [ ] Se `POSTHOG_HOST` è mancante o vuota (dopo `.trim()`), la build fallisce con messaggio guidato che indica il file da correggere
+- [ ] Il messaggio di errore include: chiave problematica, percorso del file, istruzione per correggere
+- [ ] La validazione avviene per tutti i task gulp che passano per `build()` (web, Android, iOS)
+- [ ] Dopo `create()`, `instances/posthog.json` viene copiato in `instances/<instanceName>/posthog.json`
+- [ ] La configurazione PostHog è unica e condivisa tra tutte le istanze (nessun fallback per istanza)
+
+## Rischi
+
+- **`posthog.json` è gitignored**: il file non è committato. In CI (GitHub Actions) dovrà essere creato prima del gulp tramite secrets — altrimenti la build fallirà. Questo è il comportamento corretto (esplicito), ma richiede che la pipeline CI venga aggiornata di conseguenza. **Mitigazione:** documentare il requisito nelle note e nei commenti del gulpfile.
+- **Ordine di esecuzione della copia**: la copia di `posthog.json` nell'istanza deve avvenire *dopo* `create()` (che crea la cartella `instances/<instanceName>/`). Se avviene prima, il percorso di destinazione non esiste. **Mitigazione:** inserire il copy step come primo passo dentro il `.then()` di `create()`, prima di `update()`.
+- **Local dev (`ng serve`)**: `core/posthog.json` non esiste, quindi `ng serve` diretto da `core/` fallirebbe al compile time. Questo problema è pre-esistente e fuori scope.
+
+## Out of scope
+
+- Supporto per `posthog.json` per-istanza (es. `instances/camminiditalia/posthog.json`)
+- Creazione/aggiornamento di `core/posthog.json` per il supporto a `ng serve` locale
+- Aggiornamento della pipeline CI per la gestione del secret `posthog.json`
+
+## Moduli toccati
+
+- `gulpfile.js` — nuova funzione `validatePosthogConfig()`, chiamata all'inizio di `build()`, copia del file nell'istanza dopo `create()`

--- a/docs/features/8105-gulp-validazione-posthog-json/plan.md
+++ b/docs/features/8105-gulp-validazione-posthog-json/plan.md
@@ -1,0 +1,110 @@
+> Ticket: oc:8105
+
+# Piano — Gulp: validazione posthog.json prima della build
+
+## Task 1 — Aggiungere `validatePosthogConfig()` in `gulpfile.js`
+
+**File:** `gulpfile.js`
+
+Aggiungere, dopo la funzione `abort()` esistente (riga ~244), la nuova funzione:
+
+```js
+function validatePosthogConfig() {
+  const posthogPath = instancesDir + 'posthog.json';
+
+  if (!fs.existsSync(posthogPath)) {
+    error('PostHog validation failed: file not found at ' + posthogPath);
+    error('Fix: create instances/posthog.json with POSTHOG_KEY and POSTHOG_HOST');
+    error('------------------------- Aborting -------------------------');
+    process.exit(1);
+  }
+
+  let posthogConfig;
+  try {
+    posthogConfig = JSON.parse(fs.readFileSync(posthogPath, 'utf8'));
+  } catch (e) {
+    error('PostHog validation failed: invalid JSON in ' + posthogPath);
+    error('Parse error: ' + e.message);
+    error('Fix: ensure instances/posthog.json contains valid JSON');
+    error('------------------------- Aborting -------------------------');
+    process.exit(1);
+  }
+
+  const requiredKeys = ['POSTHOG_KEY', 'POSTHOG_HOST'];
+  for (const key of requiredKeys) {
+    if (!posthogConfig[key] || !posthogConfig[key].trim()) {
+      error('PostHog validation failed: ' + key + ' is missing or empty in ' + posthogPath);
+      error('Fix: add a valid value for ' + key + ' in instances/posthog.json');
+      error('------------------------- Aborting -------------------------');
+      process.exit(1);
+    }
+  }
+
+  if (verbose) success('PostHog config validated successfully');
+}
+```
+
+**Note:**
+- Usa `process.exit(1)` per interrompere immediatamente il processo gulp (non `reject()`, perché questa funzione è sincrona e viene chiamata prima della Promise chain)
+- Usa le funzioni `error()` e `success()` già presenti nel gulpfile per coerenza visiva con il resto dei log
+
+---
+
+## Task 2 — Chiamare `validatePosthogConfig()` all'inizio di `build()`
+
+**File:** `gulpfile.js`
+
+Nella funzione `build()` (riga ~933), aggiungere la chiamata come primissima istruzione dopo i check su `instanceName` e `geohubInstanceId`:
+
+```js
+function build(instanceName, geohubInstanceId, shardName = 'geohub') {
+  return new Promise((resolve, reject) => {
+    if (!instanceName) { ... }
+    if (!geohubInstanceId) { ... }
+
+    // AGGIUNGERE QUI:
+    validatePosthogConfig();
+
+    if (verbose) debug('Starting `build(...)');
+    // ... resto della funzione invariato
+  });
+}
+```
+
+La chiamata deve stare dopo i guard su `instanceName` / `geohubInstanceId` (così gli errori di argomenti mancanti vengono ancora gestiti per primi) ma prima di qualsiasi operazione su filesystem.
+
+---
+
+## Task 3 — Copiare `posthog.json` nell'istanza dopo `create()`
+
+**File:** `gulpfile.js`
+
+Nella funzione `build()`, dentro il `.then()` di `create()`, copiare `instances/posthog.json` in `instances/<instanceName>/posthog.json` prima di chiamare `update()`:
+
+```js
+create(instanceName, force).then(
+  function () {
+    if (verbose) debug('`build()` - create completed');
+
+    // AGGIUNGERE QUI:
+    fs.copyFileSync(instancesDir + 'posthog.json', instancesDir + instanceName + '/posthog.json');
+    if (verbose) debug('posthog.json copied to instance');
+
+    if (verbose) debug('`build()`- running `update()`');
+    update(instanceName, geohubInstanceId, shardName).then( ... );
+  },
+  ...
+);
+```
+
+**Perché dopo `create()` e non prima:** `create()` crea la cartella `instances/<instanceName>/`. Se la copia avviene prima, la destinazione non esiste.
+
+---
+
+## Task 4 — Commit
+
+```
+feat(oc:8105): validate posthog.json before gulp build
+```
+
+Staged files: `gulpfile.js`, `docs/features/8105-gulp-validazione-posthog-json/`

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -517,6 +517,41 @@ function abort(err) {
   error('------------------------- Aborting -------------------------');
 }
 
+const ABORTING_BANNER = '------------------------- Aborting -------------------------';
+
+function validatePosthogConfig() {
+  const posthogPath = instancesDir + 'posthog.json';
+
+  let posthogConfig;
+  try {
+    posthogConfig = JSON.parse(fs.readFileSync(posthogPath, 'utf8'));
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      error('PostHog validation failed: file not found at ' + posthogPath);
+      error('Fix: create ' + posthogPath + ' with POSTHOG_KEY and POSTHOG_HOST');
+    } else {
+      error('PostHog validation failed: invalid JSON in ' + posthogPath);
+      error('Parse error: ' + err.message);
+      error('Fix: ensure ' + posthogPath + ' contains valid JSON');
+    }
+    error(ABORTING_BANNER);
+    throw new Error('PostHog config validation failed');
+  }
+
+  const requiredKeys = ['POSTHOG_KEY', 'POSTHOG_HOST'];
+  for (const key of requiredKeys) {
+    const val = posthogConfig[key];
+    if (!val || typeof val !== 'string' || !val.trim()) {
+      error('PostHog validation failed: ' + key + ' is missing or empty in ' + posthogPath);
+      error('Fix: add a valid string value for ' + key + ' in ' + posthogPath);
+      error(ABORTING_BANNER);
+      throw new Error('PostHog config validation failed: ' + key);
+    }
+  }
+
+  if (verbose) success('PostHog config validated successfully');
+}
+
 function checkBuildsFolder() {
   if (!fs.existsSync('builds/')) {
     if (verbose) debug('Creating builds folder...');
@@ -947,6 +982,8 @@ function build(instanceName, geohubInstanceId, shardName = 'geohub') {
       return;
     }
 
+    validatePosthogConfig();
+
     if (verbose) debug('Starting `build(' + instanceName + ',' + geohubInstanceId + ')`');
     if (verbose) debug('`build()`- running `create()`');
     var force = false;
@@ -954,6 +991,13 @@ function build(instanceName, geohubInstanceId, shardName = 'geohub') {
     create(instanceName, force).then(
       function () {
         if (verbose) debug('`build()` - create completed');
+        try {
+          fs.copyFileSync(instancesDir + 'posthog.json', instancesDir + instanceName + '/posthog.json');
+          if (verbose) debug('posthog.json copied to instance');
+        } catch (err) {
+          reject(new Error('Failed to copy posthog.json to instance: ' + err.message));
+          return;
+        }
         if (verbose) debug('`build()`- running `update()`');
         update(instanceName, geohubInstanceId, shardName).then(
           result => {


### PR DESCRIPTION
## Summary

- Aggiunge `validatePosthogConfig()` in `gulpfile.js`: controlla esistenza file, JSON valido e chiavi `POSTHOG_KEY`/`POSTHOG_HOST` non vuote (con `.trim()`)
- La build fallisce immediatamente con messaggio guidato se la validazione non passa
- Copia `instances/posthog.json` → `instances/<instanceName>/posthog.json` dopo `create()`
- Usa `throw` invece di `process.exit(1)` per rejection pulita nella Promise chain di Gulp
- `fs.copyFileSync` wrappato in try/catch per evitare unhandled Promise rejection

## ⚠️ Nota CI

`instances/posthog.json` è gitignored — verificare che il secret sia configurato in GitHub Actions prima del merge.

## Test plan

- [ ] `gulp build -i <istanza> -g <id>` con `instances/posthog.json` valido → build prosegue normalmente
- [ ] `gulp build` con file mancante → errore esplicito `PostHog validation failed: file not found`
- [ ] `gulp build` con JSON malformato → errore con dettaglio parse error
- [ ] `gulp build` con `POSTHOG_KEY` vuota → errore con nome chiave e percorso file
- [ ] `gulp build` con `POSTHOG_HOST` con soli spazi → errore (trim check)
- [ ] `gulp build-android` e `gulp build-ios` → stessa validazione attiva

🤖 Generated with [Claude Code](https://claude.com/claude-code)