### PR TITLE
feat(oc:8176): add favorites tab for layers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,8 +169,16 @@ Angular 20 · Ionic 8 · Capacitor 7 · NgRx 20 · OpenLayers 7 · @ngx-translat
 | Gestione permessi Android nel manifest | oc:7294 | `gulpfile.js` | READ_MEDIA_IMAGES sempre rimosso; READ/WRITE_EXTERNAL_STORAGE aggiunti solo se MAP.record_track_show===true (letto da dir/config.json); addPermissionsIfNotPresent() sostituita da manageAndroidPermissions(hasUgc) |
 | Documentazione downloadOverlay e hitMapUrl per shard carg | oc:8190 | `core/src/app/pages/map/map.page.html`, `core/src/app/pages/map/download-panel/download-panel.component.ts` | Documenta il meccanismo di download overlay hitmap e il campo hitMapUrl, oggi attivi solo per carg |
 | Validazione dimensioni icon/notification_icon/splash prima di cordova-res | oc:8246 | `gulpfile.js` | Valida dimensioni (platform-specific) prima di ogni cordova-res; sotto soglia chiede conferma interattiva (mai blocco automatico), flag `--skip-resource-validation` come escape hatch |
+| Salva cammino nei preferiti | oc:8176 | `core/src/app/pages/favourites/*`, `core/tsconfig.spec.json`, `core/angular.json`, `core/src/assets/i18n/*` | Tab "Layers"/"Sentieri" in `FavouritesPage` (ordine invertito su richiesta post-hoc), riusa `wm-layer-box`/`LayerFavoriteService` da wm-core. Dettagli in `docs/features/8176-salva-cammino-nei-preferiti/notes.md` |
 
 ## Decisioni architetturali
+
+### Salva cammino nei preferiti (oc:8176)
+- **Il ticket originale descriveva erroneamente i preferiti-tracce come "non implementati"**: il tab Favourites (tracce) era già in produzione (`FavouritesPage`, `map-track-card`, endpoint `EcTrackController`) — il lavoro reale è stata l'estensione a un secondo tab "Layers", non la costruzione da zero
+- **`ion-segment` invece di `ion-tabs` annidati** per il cambio Layers/Sentieri dentro `FavouritesPage` — evita di generare voci di navigazione/history per un semplice cambio di vista in-page
+- **Ordine e naming tab decisi post-hoc dal developer dopo verifica visiva**: "Layers" (stessa parola in tutte le 7 lingue, scelta deliberata) prima di "Sentieri" (ex "Cammini"/"Tracce"), diverso da quanto originariamente pianificato
+- **`UrlHandlerService.setLayer()` (wm-core) usa `changeURL()` non `updateURL()`**: `updateURL()` naviga solo se i query param cambiano — se lo stesso layer era già in URL da una navigazione precedente (es. aperto dalla Home) il click dal tab Preferiti non avrebbe navigato affatto verso `/map`. Bug trovato e corretto in review formale prima del merge
+- **`tsconfig.spec.json`/`angular.json` estesi con `src/app/pages/favourites`** (oltre al preesistente `src/app/services`, oc:8023) per includere i nuovi test in CI — scoping minimale, non riapre la discovery a `src/**`
 
 ### Validazione dimensioni icon/notification_icon/splash prima di cordova-res (oc:8246)
 - **Soglie platform-specific, non universali**: verificate nel sorgente reale di `cordova-res` (`core/node_modules/cordova-res/dist/resources.js`, `getRasterResourceSchema`), non nel solo README (che riporta 2732×2732 come raccomandazione "universale" per un source che copra tutte le piattaforme, fuorviante se letto come requisito Android). Requisiti reali: Android icon/notification_icon ≥512×512 (usiamo 1024×1024 come margine), Android splash ≥1920×1920, iOS icon ≥1024×1024, iOS splash ≥2732×2732. `validateRasterResource` in quel file non impone aspect ratio 1:1, solo dimensioni minime

--- a/core/angular.json
+++ b/core/angular.json
@@ -129,7 +129,8 @@
             "tsConfig": "tsconfig.spec.json",
             "karmaConfig": "karma.conf.js",
             "include": [
-              "src/app/services"
+              "src/app/services",
+              "src/app/pages/favourites"
             ],
             "stylePreprocessorOptions": {
               "includePaths": ["src/theme/default"]

--- a/core/src/app/pages/favourites/favourites-layers/favourites-layers.component.html
+++ b/core/src/app/pages/favourites/favourites-layers/favourites-layers.component.html
@@ -1,0 +1,19 @@
+<ion-label class="webmapp-favourites-nodata" *ngIf="loadError">
+  {{'Impossibile caricare i cammini preferiti, riprova' | wmtrans}}
+</ion-label>
+
+<ng-container *ngIf="!loadError">
+  <ng-container *ngIf="layerBoxes$|async as boxes">
+    <ion-label class="webmapp-favourites-nodata" *ngIf="!loading && !boxes.length">
+      {{'pages.favourites.nodataLayers' | wmtrans}}
+    </ion-label>
+    <ion-list>
+      <wm-layer-box
+        *ngFor="let box of boxes; trackBy: trackByLayerId"
+        [data]="box"
+        [favoriteInteractive]="true"
+        (clickEVT)="openLayer(box.layer)"
+      ></wm-layer-box>
+    </ion-list>
+  </ng-container>
+</ng-container>

--- a/core/src/app/pages/favourites/favourites-layers/favourites-layers.component.html
+++ b/core/src/app/pages/favourites/favourites-layers/favourites-layers.component.html
@@ -5,7 +5,7 @@
 <ng-container *ngIf="!loadError">
   <ng-container *ngIf="layerBoxes$|async as boxes">
     <ion-label class="webmapp-favourites-nodata" *ngIf="!loading && !boxes.length">
-      {{'pages.favourites.nodataLayers' | wmtrans}}
+      {{'Non ci sono cammini preferiti, clicca sull\'icona cuore di un cammino per aggiungerlo a questa lista' | wmtrans}}
     </ion-label>
     <ion-list>
       <wm-layer-box

--- a/core/src/app/pages/favourites/favourites-layers/favourites-layers.component.scss
+++ b/core/src/app/pages/favourites/favourites-layers/favourites-layers.component.scss
@@ -1,0 +1,20 @@
+:host {
+  display: block;
+
+  wm-layer-box {
+    // Senza un'altezza esplicita, .wm-box (height:100%) non ha un containing block
+    // definito dentro ion-list e collassa all'altezza del solo contenuto in flow —
+    // stessa altezza usata dalla griglia Home.
+    display: block;
+    height: 176px;
+  }
+
+  // .webmapp-favourites-nodata vive in favourites.page.scss, ma l'encapsulation
+  // Emulated di default non la propaga a questo componente figlio (view boundary
+  // separata) — ridefinita qui identica per lo stato vuoto/errore di questo tab.
+  .webmapp-favourites-nodata {
+    padding: 30px;
+    display: block;
+    color: var(--wm-color-darkgrey);
+  }
+}

--- a/core/src/app/pages/favourites/favourites-layers/favourites-layers.component.spec.ts
+++ b/core/src/app/pages/favourites/favourites-layers/favourites-layers.component.spec.ts
@@ -1,0 +1,76 @@
+import {ChangeDetectorRef} from '@angular/core';
+import {LayerFavoriteService} from '@wm-core/services/layer-favorite.service';
+import {UrlHandlerService} from '@wm-core/services/url-handler.service';
+import {ILAYER} from '@wm-core/types/config';
+import {of} from 'rxjs';
+
+import {FavouritesLayersComponent} from './favourites-layers.component';
+
+describe('FavouritesLayersComponent (oc:8176)', () => {
+  const fakeLayer: ILAYER = {id: '3', title: 'Cammino preferito'} as any;
+
+  let urlHandlerSvcSpy: jasmine.SpyObj<UrlHandlerService>;
+
+  function createComponent(
+    favorites: ILAYER[],
+    getFavoritesError = false,
+  ): {component: FavouritesLayersComponent; cdrSpy: jasmine.SpyObj<ChangeDetectorRef>} {
+    const favoriteSvcSpy = jasmine.createSpyObj<LayerFavoriteService>('LayerFavoriteService', [
+      'getFavorites',
+    ]);
+    (favoriteSvcSpy as any).favorites$ = of(favorites);
+    if (getFavoritesError) {
+      favoriteSvcSpy.getFavorites.and.rejectWith(new Error('network error'));
+    } else {
+      favoriteSvcSpy.getFavorites.and.resolveTo(favorites);
+    }
+    urlHandlerSvcSpy = jasmine.createSpyObj<UrlHandlerService>('UrlHandlerService', ['setLayer']);
+    const cdrSpy = jasmine.createSpyObj<ChangeDetectorRef>('ChangeDetectorRef', ['markForCheck']);
+
+    return {
+      component: new FavouritesLayersComponent(favoriteSvcSpy, urlHandlerSvcSpy, cdrSpy),
+      cdrSpy,
+    };
+  }
+
+  it('espone loadError = true se getFavorites fallisce', async () => {
+    const {component} = createComponent([], true);
+    await component.ngOnInit();
+    expect(component.loadError).toBeTrue();
+  });
+
+  it('espone loadError = false e la lista se getFavorites va a buon fine', async () => {
+    const {component} = createComponent([fakeLayer]);
+    await component.ngOnInit();
+    expect(component.loadError).toBeFalse();
+
+    let layers: ILAYER[];
+    component.layers$.subscribe(v => (layers = v));
+    expect(layers).toEqual([fakeLayer]);
+  });
+
+  it('avvolge ogni layer in un box di tipo layer per wm-layer-box', async () => {
+    const {component} = createComponent([fakeLayer]);
+    await component.ngOnInit();
+
+    let boxes: any[];
+    component.layerBoxes$.subscribe(v => (boxes = v));
+    expect(boxes).toEqual([{box_type: 'layer', title: fakeLayer.title, layer: fakeLayer}]);
+  });
+
+  it('chiama markForCheck() sul ChangeDetectorRef quando getFavorites fallisce (OnPush)', async () => {
+    const {component, cdrSpy} = createComponent([], true);
+    await component.ngOnInit();
+
+    expect(component.loadError).toBeTrue();
+    expect(cdrSpy.markForCheck).toHaveBeenCalled();
+  });
+
+  it('openLayer() naviga alla mappa con il layer selezionato, come dalla Home', () => {
+    const {component} = createComponent([fakeLayer]);
+
+    component.openLayer(fakeLayer);
+
+    expect(urlHandlerSvcSpy.setLayer).toHaveBeenCalledWith(fakeLayer);
+  });
+});

--- a/core/src/app/pages/favourites/favourites-layers/favourites-layers.component.ts
+++ b/core/src/app/pages/favourites/favourites-layers/favourites-layers.component.ts
@@ -1,0 +1,69 @@
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit} from '@angular/core';
+import {LayerFavoriteService} from '@wm-core/services/layer-favorite.service';
+import {UrlHandlerService} from '@wm-core/services/url-handler.service';
+import {ILAYER, ILAYERBOX} from '@wm-core/types/config';
+import {Observable} from 'rxjs';
+import {map} from 'rxjs/operators';
+
+/**
+ * Mostra la lista dei cammini (layer) preferiti dell'utente nel tab "Cammini"
+ * della pagina Preferiti, riusando `LayerFavoriteService` e `wm-layer-box`.
+ */
+@Component({
+  standalone: false,
+  selector: 'webmapp-favourites-layers',
+  templateUrl: './favourites-layers.component.html',
+  styleUrls: ['./favourites-layers.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class FavouritesLayersComponent implements OnInit {
+  layers$: Observable<ILAYER[]> = this._layerFavoriteSvc.favorites$;
+  layerBoxes$: Observable<ILAYERBOX[]> = this.layers$.pipe(
+    map(layers => layers.map(layer => ({box_type: 'layer' as const, title: layer.title, layer}))),
+  );
+  loadError = false;
+  loading = true;
+
+  /**
+   * @param _layerFavoriteSvc Servizio per la gestione dei layer (cammini) preferiti.
+   * @param _urlHandlerSvc Naviga alla mappa con il layer selezionato al tap sulla card,
+   * stesso comportamento del click su un box layer dalla Home.
+   * @param _cdr Riferimento al change detector, necessario con `OnPush` per marcare
+   * esplicitamente la vista da ricontrollare quando lo stato muta fuori da un Observable.
+   */
+  constructor(
+    private _layerFavoriteSvc: LayerFavoriteService,
+    private _urlHandlerSvc: UrlHandlerService,
+    private _cdr: ChangeDetectorRef,
+  ) {}
+
+  openLayer(layer: ILAYER): void {
+    this._urlHandlerSvc.setLayer(layer);
+  }
+
+  /**
+   * `trackBy` per `*ngFor`: `layerBoxes$` rimappa ogni layer in un nuovo oggetto
+   * letterale ad ogni emissione di `favorites$` (es. dopo un toggle), quindi senza
+   * `trackBy` Angular distruggerebbe e ricreerebbe tutte le card ad ogni singola
+   * variazione di preferito invece di quella toccata soltanto.
+   */
+  trackByLayerId(_index: number, box: ILAYERBOX): string {
+    return box.layer.id;
+  }
+
+  /**
+   * Carica la lista dei layer preferiti al mount del componente, esponendo
+   * `loadError` in caso di fallimento.
+   */
+  async ngOnInit(): Promise<void> {
+    try {
+      await this._layerFavoriteSvc.getFavorites();
+      this.loadError = false;
+    } catch {
+      this.loadError = true;
+    } finally {
+      this.loading = false;
+      this._cdr.markForCheck();
+    }
+  }
+}

--- a/core/src/app/pages/favourites/favourites.module.ts
+++ b/core/src/app/pages/favourites/favourites.module.ts
@@ -7,8 +7,10 @@ import {IonicModule} from '@ionic/angular';
 import {FavouritesPageRoutingModule} from './favourites-routing.module';
 
 import {FavouritesPage} from './favourites.page';
+import {FavouritesLayersComponent} from './favourites-layers/favourites-layers.component';
 import {CardsModule} from 'src/app/components/cards/cards.module';
 import {WmPipeModule} from '@wm-core/pipes/pipe.module';
+import {BoxModule} from 'src/app/components/box/box.module';
 
 @NgModule({
   imports: [
@@ -18,7 +20,8 @@ import {WmPipeModule} from '@wm-core/pipes/pipe.module';
     FavouritesPageRoutingModule,
     WmPipeModule,
     CardsModule,
+    BoxModule,
   ],
-  declarations: [FavouritesPage],
+  declarations: [FavouritesPage, FavouritesLayersComponent],
 })
 export class FavouritesPageModule {}

--- a/core/src/app/pages/favourites/favourites.page.html
+++ b/core/src/app/pages/favourites/favourites.page.html
@@ -7,10 +7,10 @@
   <ion-toolbar *ngIf="showLayersSegment$|async">
     <ion-segment [value]="selectedSegment" (ionChange)="onSegmentChange($event.detail.value)">
       <ion-segment-button value="layers">
-        <ion-label>{{'pages.favourites.tabs.layers' | wmtrans}}</ion-label>
+        <ion-label>{{'Layers' | wmtrans}}</ion-label>
       </ion-segment-button>
       <ion-segment-button value="tracks">
-        <ion-label>{{'pages.favourites.tabs.tracks' | wmtrans}}</ion-label>
+        <ion-label>{{'Sentieri' | wmtrans}}</ion-label>
       </ion-segment-button>
     </ion-segment>
   </ion-toolbar>

--- a/core/src/app/pages/favourites/favourites.page.html
+++ b/core/src/app/pages/favourites/favourites.page.html
@@ -4,26 +4,40 @@
       {{'pages.favourites.title' | wmtrans}}
     </ion-title>
   </ion-toolbar>
+  <ion-toolbar *ngIf="showLayersSegment$|async">
+    <ion-segment [value]="selectedSegment" (ionChange)="onSegmentChange($event.detail.value)">
+      <ion-segment-button value="layers">
+        <ion-label>{{'pages.favourites.tabs.layers' | wmtrans}}</ion-label>
+      </ion-segment-button>
+      <ion-segment-button value="tracks">
+        <ion-label>{{'pages.favourites.tabs.tracks' | wmtrans}}</ion-label>
+      </ion-segment-button>
+    </ion-segment>
+  </ion-toolbar>
 </ion-header>
 
 <ion-content>
-  <ion-refresher slot="fixed" (ionRefresh)="doRefresh($event)">
+  <ion-refresher slot="fixed" (ionRefresh)="doRefresh($event)" *ngIf="selectedSegment === 'tracks'">
     <ion-refresher-content></ion-refresher-content>
   </ion-refresher>
   <ng-container *ngIf="isLogged$|async;else nologged">
-    <ng-container *ngIf="tracks$|async as tracks">
-      <ion-label class="webmapp-favourites-nodata" *ngIf="!tracks || !tracks.length"
-        >{{'pages.favourites.nodata' | wmtrans}}</ion-label
-      >
-      <ion-list>
-        <webmapp-card-track
-          *ngFor="let track of tracks"
-          [track]="track"
-          (open)="open($event)"
-          (remove)="remove($event)"
+    <ng-container *ngIf="selectedSegment === 'tracks'">
+      <ng-container *ngIf="tracks$|async as tracks">
+        <ion-label class="webmapp-favourites-nodata" *ngIf="!tracks || !tracks.length"
+          >{{'pages.favourites.nodata' | wmtrans}}</ion-label
         >
-        </webmapp-card-track> </ion-list
-    ></ng-container>
+        <ion-list>
+          <webmapp-card-track
+            *ngFor="let track of tracks"
+            [track]="track"
+            (open)="open($event)"
+            (remove)="remove($event)"
+          >
+          </webmapp-card-track> </ion-list
+      ></ng-container>
+    </ng-container>
+
+    <webmapp-favourites-layers *ngIf="selectedSegment === 'layers'"></webmapp-favourites-layers>
   </ng-container>
   <ng-template #nologged>
     <ion-label class="webmapp-favourites-nodata">
@@ -32,7 +46,11 @@
     >
   </ng-template>
 
-  <ion-infinite-scroll threshold="100px" (ionInfinite)="loadData($event)">
+  <ion-infinite-scroll
+    *ngIf="selectedSegment === 'tracks'"
+    threshold="100px"
+    (ionInfinite)="loadData($event)"
+  >
     <ion-infinite-scroll-content loadingSpinner="bubbles" loadingText="Loading more data...">
     </ion-infinite-scroll-content>
   </ion-infinite-scroll>

--- a/core/src/app/pages/favourites/favourites.page.scss
+++ b/core/src/app/pages/favourites/favourites.page.scss
@@ -81,3 +81,7 @@
         font-weight: var(--wm-font-weight-light);
     }
 }
+
+ion-segment {
+  --background: transparent;
+}

--- a/core/src/app/pages/favourites/favourites.page.spec.ts
+++ b/core/src/app/pages/favourites/favourites.page.spec.ts
@@ -1,0 +1,45 @@
+import {Store} from '@ngrx/store';
+import {of} from 'rxjs';
+import {GeohubService} from 'src/app/services/geohub.service';
+import {UrlHandlerService} from '@wm-core/services/url-handler.service';
+
+import {FavouritesPage} from './favourites.page';
+
+describe('FavouritesPage — segmento Tracce/Cammini (oc:8176)', () => {
+  function createPage(showFavorites: boolean): FavouritesPage {
+    const storeSpy = jasmine.createSpyObj<Store>('Store', ['select', 'pipe']);
+    storeSpy.select.and.returnValue(of(showFavorites));
+    storeSpy.pipe.and.returnValue(of(false));
+    const geoHubSvcSpy = jasmine.createSpyObj<GeohubService>('GeohubService', [
+      'getFavouriteTracks',
+      'setFavouriteTrack',
+    ]);
+    geoHubSvcSpy.getFavouriteTracks.and.resolveTo([]);
+    const urlHandlerSvcSpy = jasmine.createSpyObj<UrlHandlerService>('UrlHandlerService', [
+      'changeURL',
+    ]);
+
+    return new FavouritesPage(geoHubSvcSpy, storeSpy, urlHandlerSvcSpy);
+  }
+
+  it('parte con il segmento "tracks" selezionato', () => {
+    const page = createPage(true);
+    expect(page.selectedSegment).toBe('tracks');
+  });
+
+  it('espone showLayersSegment$ come true quando showFavorites è true', done => {
+    const page = createPage(true);
+    page.showLayersSegment$.subscribe(v => {
+      expect(v).toBe(true);
+      done();
+    });
+  });
+
+  it('espone showLayersSegment$ come false quando showFavorites è false', done => {
+    const page = createPage(false);
+    page.showLayersSegment$.subscribe(v => {
+      expect(v).toBe(false);
+      done();
+    });
+  });
+});

--- a/core/src/app/pages/favourites/favourites.page.ts
+++ b/core/src/app/pages/favourites/favourites.page.ts
@@ -5,6 +5,7 @@ import {NavigationExtras, Router} from '@angular/router';
 import {BehaviorSubject, Observable} from 'rxjs';
 import {select, Store} from '@ngrx/store';
 import {isLogged} from '@wm-core/store/auth/auth.selectors';
+import {confOPTIONSShowFavorites} from '@wm-core/store/conf/conf.selector';
 import {Feature, LineString} from 'geojson';
 import {UrlHandlerService} from '@wm-core/services/url-handler.service';
 @Component({
@@ -19,6 +20,8 @@ export class FavouritesPage implements OnInit {
   @ViewChild(IonInfiniteScroll) infiniteScroll: IonInfiniteScroll;
 
   isLogged$: Observable<boolean> = this._store.pipe(select(isLogged));
+  showLayersSegment$: Observable<boolean> = this._store.select(confOPTIONSShowFavorites);
+  selectedSegment: 'tracks' | 'layers' = 'tracks';
   tracks$: BehaviorSubject<Feature<LineString>[]> = new BehaviorSubject<Feature<LineString>[]>(
     null,
   );
@@ -31,6 +34,10 @@ export class FavouritesPage implements OnInit {
 
   async ngOnInit() {
     this.doRefresh(null);
+  }
+
+  onSegmentChange(segment: 'tracks' | 'layers'): void {
+    this.selectedSegment = segment;
   }
 
   async doRefresh(event) {

--- a/core/src/assets/i18n/de.ts
+++ b/core/src/assets/i18n/de.ts
@@ -200,12 +200,7 @@ export const appDE = {
     },
     'favourites': {
       'nodata': 'Es gibt keine Favoritenstrecken, klicken Sie auf das Herzsymbol einer Strecke, um sie zu dieser Liste hinzuzufügen',
-      'title': 'Favoriten',
-      'tabs': {
-        'tracks': 'Wanderwege',
-        'layers': 'Layers'
-      },
-      'nodataLayers': 'Es gibt keine Favoritenwege, klicken Sie auf das Herzsymbol eines Weges, um ihn zu dieser Liste hinzuzufügen'
+      'title': 'Favoriten'
     },
     'home': {
       'button': 'Wählen Sie einen Startpunkt',
@@ -543,6 +538,10 @@ export const appDE = {
       'content': 'Wandern in der Natur und allgemein Outdoor-Aktivitäten sind potenziell gefährliche Aktivitäten: Bevor Sie sich auf eine Exkursion begeben, stellen Sie sicher, dass Sie über das Wissen und die Fähigkeiten verfügen, dies zu tun. Wenn Sie sich nicht sicher sind, wenden Sie sich an lokale Experten, die Ihnen helfen, vorschlagen und unterstützen können, Ihre Aktivitäten zu planen und durchzuführen. Die in dieser APP präsentierten Daten können die risikofreie Befahrbarkeit der Strecke nicht vollständig garantieren: Seit der letzten Überprüfung der Strecke können sich Änderungen, auch wesentliche, ergeben haben. Daher ist es unerlässlich, dass diejenigen, die Aktivitäten entwickeln möchten, sorgfältig die Möglichkeit des Fortfahrens auf der Grundlage der in dieser APP enthaltenen Vorschläge und Ratschläge, ihrer Erfahrung, der Wetterbedingungen (auch der vorherigen Tage) und einer vor Ort durchgeführten Bewertung zu Beginn der Aktivität bewerten. Die Firma Webmapp S.r.l. bietet keine Garantie für die Sicherheit der beschriebenen Orte und übernimmt keine Verantwortung für mögliche Schäden, die durch die Durchführung der beschriebenen Aktivitäten entstehen.'
     }
   },
+  'Layers': 'Layers',
+  'Sentieri': 'Wanderwege',
+  'Non ci sono cammini preferiti, clicca sull\'icona cuore di un cammino per aggiungerlo a questa lista':
+    'Es gibt keine Favoritenwege, klicken Sie auf das Herzsymbol eines Weges, um ihn zu dieser Liste hinzuzufügen',
   'services': {
     'geolocation': {
       'notification': {

--- a/core/src/assets/i18n/de.ts
+++ b/core/src/assets/i18n/de.ts
@@ -200,7 +200,12 @@ export const appDE = {
     },
     'favourites': {
       'nodata': 'Es gibt keine Favoritenstrecken, klicken Sie auf das Herzsymbol einer Strecke, um sie zu dieser Liste hinzuzufügen',
-      'title': 'Favoriten'
+      'title': 'Favoriten',
+      'tabs': {
+        'tracks': 'Wanderwege',
+        'layers': 'Layers'
+      },
+      'nodataLayers': 'Es gibt keine Favoritenwege, klicken Sie auf das Herzsymbol eines Weges, um ihn zu dieser Liste hinzuzufügen'
     },
     'home': {
       'button': 'Wählen Sie einen Startpunkt',
@@ -592,6 +597,8 @@ export const appDE = {
   'Ti trovi qui': 'Sie sind hier',
   'Salva Waypoint': 'Wegpunkt speichern',
   'Salva Traccia': 'Strecke speichern',
+  'Impossibile caricare i cammini preferiti, riprova':
+    'Die Favoritenwege konnten nicht geladen werden, versuchen Sie es erneut',
   'privacy': {
     'agree': {
       'title': 'Datenverarbeitung',

--- a/core/src/assets/i18n/en.ts
+++ b/core/src/assets/i18n/en.ts
@@ -201,12 +201,7 @@ export const appEN = {
     },
     'favourites': {
       'nodata': 'There are no favorite heart tracks, click on a track icon to add it to this list',
-      'title': 'Favourites',
-      'tabs': {
-        'tracks': 'Trails',
-        'layers': 'Layers'
-      },
-      'nodataLayers': 'There are no favorite paths, click on the heart icon of a path to add it to this list'
+      'title': 'Favourites'
     },
     'home': {
       'button': 'Choose a starting point',
@@ -546,6 +541,10 @@ export const appEN = {
       'content': 'Hiking and, more generally, outdoor activity, is a potentially risky activity: before setting out on a hike, make sure you have the knowledge and skills to do it. If you are not sure, contact local experts who can help, suggest and support you in planning and carrying out your activities. The data presented on this APP cannot fully guarantee the risk-free practicability of the route: changes, even important ones, may have occurred since the last verification of the route itself. It is therefore essential that those who are preparing to carry out activities carefully evaluate the opportunity to continue on the basis of the suggestions and advice contained in this APP, based on their experience, on the weather conditions (even in the previous days) and on an evaluation in the field at the beginning of the activity. Webmapp S.r.l. does not provide guarantees on the safety of the places described and assumes no responsibility for any damage caused by carrying out the activities described.'
     }
   },
+  'Layers': 'Layers',
+  'Sentieri': 'Trails',
+  'Non ci sono cammini preferiti, clicca sull\'icona cuore di un cammino per aggiungerlo a questa lista':
+    'There are no favorite paths, click on the heart icon of a path to add it to this list',
   'services': {
     'geolocation': {
       'notification': {

--- a/core/src/assets/i18n/en.ts
+++ b/core/src/assets/i18n/en.ts
@@ -201,7 +201,12 @@ export const appEN = {
     },
     'favourites': {
       'nodata': 'There are no favorite heart tracks, click on a track icon to add it to this list',
-      'title': 'Favourites'
+      'title': 'Favourites',
+      'tabs': {
+        'tracks': 'Trails',
+        'layers': 'Layers'
+      },
+      'nodataLayers': 'There are no favorite paths, click on the heart icon of a path to add it to this list'
     },
     'home': {
       'button': 'Choose a starting point',
@@ -612,6 +617,8 @@ export const appEN = {
   'Ti trovi qui': 'You are here',
   'Salva Waypoint': 'Save Waypoint',
   'Salva Traccia': 'Save track',
+  'Impossibile caricare i cammini preferiti, riprova':
+    'Unable to load favorite paths, please try again',
   'Cancella': 'Delete',
   'ATTENZIONE': 'WARNING',
   'Foto correttamente cancellata': 'Photo successfully deleted',

--- a/core/src/assets/i18n/es.ts
+++ b/core/src/assets/i18n/es.ts
@@ -200,7 +200,12 @@ export const appES = {
     },
     'favourites': {
       'nodata': 'No hay rutas favoritas, haz clic en el icono de corazón de una ruta para añadirla a esta lista',
-      'title': 'Favoritos'
+      'title': 'Favoritos',
+      'tabs': {
+        'tracks': 'Senderos',
+        'layers': 'Layers'
+      },
+      'nodataLayers': 'No hay caminos favoritos, haz clic en el icono de corazón de un camino para añadirlo a esta lista'
     },
     'home': {
       'button': 'Elige un punto de partida',
@@ -592,6 +597,8 @@ export const appES = {
   'Ti trovi qui': 'Estás aquí',
   'Salva Waypoint': 'Guardar punto de referencia',
   'Salva Traccia': 'Guardar ruta',
+  'Impossibile caricare i cammini preferiti, riprova':
+    'No se pudieron cargar los caminos favoritos, inténtalo de nuevo',
   'privacy': {
     'agree': {
       'title': 'Procesamiento de datos',

--- a/core/src/assets/i18n/es.ts
+++ b/core/src/assets/i18n/es.ts
@@ -200,12 +200,7 @@ export const appES = {
     },
     'favourites': {
       'nodata': 'No hay rutas favoritas, haz clic en el icono de corazón de una ruta para añadirla a esta lista',
-      'title': 'Favoritos',
-      'tabs': {
-        'tracks': 'Senderos',
-        'layers': 'Layers'
-      },
-      'nodataLayers': 'No hay caminos favoritos, haz clic en el icono de corazón de un camino para añadirlo a esta lista'
+      'title': 'Favoritos'
     },
     'home': {
       'button': 'Elige un punto de partida',
@@ -543,6 +538,10 @@ export const appES = {
       'content': 'Caminar en la naturaleza y, en general, las actividades al aire libre, son actividades potencialmente peligrosas: antes de partir para una excursión, asegúrate de tener el conocimiento y las habilidades para hacerlo. Si no estás seguro, dirígete a expertos locales que puedan ayudarte, sugerir y apoyar en la planificación y desarrollo de tus actividades. Los datos presentados en esta APLICACIÓN no pueden garantizar completamente la viabilidad sin riesgos de la ruta: pueden haber ocurrido cambios, incluso significativos, desde la última verificación de la ruta. Por lo tanto, es esencial que aquellos que planean desarrollar actividades evalúen cuidadosamente la posibilidad de continuar basándose en las sugerencias y consejos contenidos en esta APLICACIÓN, basándose en su experiencia, las condiciones meteorológicas (incluso de los días anteriores) y una evaluación realizada en el terreno al inicio del desarrollo de la actividad. La empresa Webmapp S.r.l. no ofrece garantías para la seguridad de los lugares descritos y no asume ninguna responsabilidad por posibles daños causados por el desarrollo de las actividades descritas.'
     }
   },
+  'Layers': 'Layers',
+  'Sentieri': 'Senderos',
+  'Non ci sono cammini preferiti, clicca sull\'icona cuore di un cammino per aggiungerlo a questa lista':
+    'No hay caminos favoritos, haz clic en el icono de corazón de un camino para añadirlo a esta lista',
   'services': {
     'geolocation': {
       'notification': {

--- a/core/src/assets/i18n/fr.ts
+++ b/core/src/assets/i18n/fr.ts
@@ -201,12 +201,7 @@ export const appFR = {
     },
     'favourites': {
       'nodata': 'Il n\'y a pas de traces favorites, cliquez sur une icône de piste pour l\'ajouter à cette liste',
-      'title': 'Favoris',
-      'tabs': {
-        'tracks': 'Sentiers',
-        'layers': 'Layers'
-      },
-      'nodataLayers': 'Il n\'y a pas de chemins favoris, cliquez sur l\'icône de cœur d\'un chemin pour l\'ajouter à cette liste'
+      'title': 'Favoris'
     },
     'home': {
       'button': 'Choisissez un point de départ',
@@ -546,6 +541,10 @@ export const appFR = {
       'content': 'La pratique de la randonnée, et plus généralement des activités de plein air, est une activité potentiellement à risque : avant de partir en randonnée, assurez-vous d\'avoir les connaissances et les compétences pour la pratiquer. En cas de doute, contactez des experts locaux qui pourront vous aider, vous suggérer et vous accompagner dans la planification et la réalisation de vos activités. Les données présentées sur cette APP ne peuvent pleinement garantir la praticabilité sans risque de l\'itinéraire : des changements, même importants, peuvent être intervenus depuis la dernière vérification de l\'itinéraire lui-même. Il est donc essentiel que ceux qui se préparent à réaliser des activités évaluent soigneusement l\'opportunité de continuer sur la base des suggestions et des conseils contenus dans cette APP, en fonction de leur expérience, des conditions météorologiques (même les jours précédents) et des une évaluation sur le terrain au début de l\'activité. Webmapp S.r.l. ne fournit aucune garantie sur la sécurité des lieux décrits et n\'assume aucune responsabilité pour tout dommage causé par la réalisation des activités décrites.'
     }
   },
+  'Layers': 'Layers',
+  'Sentieri': 'Sentiers',
+  'Non ci sono cammini preferiti, clicca sull\'icona cuore di un cammino per aggiungerlo a questa lista':
+    'Il n\'y a pas de chemins favoris, cliquez sur l\'icône de cœur d\'un chemin pour l\'ajouter à cette liste',
   'services': {
     'geolocation': {
       'notification': {

--- a/core/src/assets/i18n/fr.ts
+++ b/core/src/assets/i18n/fr.ts
@@ -201,7 +201,12 @@ export const appFR = {
     },
     'favourites': {
       'nodata': 'Il n\'y a pas de traces favorites, cliquez sur une icône de piste pour l\'ajouter à cette liste',
-      'title': 'Favoris'
+      'title': 'Favoris',
+      'tabs': {
+        'tracks': 'Sentiers',
+        'layers': 'Layers'
+      },
+      'nodataLayers': 'Il n\'y a pas de chemins favoris, cliquez sur l\'icône de cœur d\'un chemin pour l\'ajouter à cette liste'
     },
     'home': {
       'button': 'Choisissez un point de départ',
@@ -601,6 +606,8 @@ export const appFR = {
   'Ti trovi qui': 'Vous êtes ici',
   'Salva Waypoint': 'Enregistrer le waypoint',
   'Salva Traccia': 'Enregistrer la trace',
+  'Impossibile caricare i cammini preferiti, riprova':
+    'Impossible de charger les chemins favoris, veuillez réessayer',
   'Scarica il tracciato GPX': 'Télécharger la trace GPX',
   'Scarica il tracciato KML': 'Télécharger la trace KML',
   'Scarica il tracciato GEOJSON': 'Télécharger la trace GEOJSON',

--- a/core/src/assets/i18n/it.ts
+++ b/core/src/assets/i18n/it.ts
@@ -206,6 +206,12 @@ export const appIT = {
       'nodata':
         "Non ci sono tracce preferite, clicca sull'icona cuore di una traccia per aggiungerla a questa lista",
       'title': 'Preferiti',
+      'tabs': {
+        'tracks': 'Sentieri',
+        'layers': 'Layers',
+      },
+      'nodataLayers':
+        "Non ci sono cammini preferiti, clicca sull'icona cuore di un cammino per aggiungerlo a questa lista",
     },
     'home': {
       'button': 'Scegli un punto di partenza',
@@ -630,6 +636,8 @@ export const appIT = {
   'Ti trovi qui': 'Ti trovi qui',
   'Salva Waypoint': 'Salva Waypoint',
   'Salva Traccia': 'Salva Traccia',
+  'Impossibile caricare i cammini preferiti, riprova':
+    'Impossibile caricare i cammini preferiti, riprova',
   'privacy': {
     'agree': {
       'title': 'Trattamento dei dati',

--- a/core/src/assets/i18n/it.ts
+++ b/core/src/assets/i18n/it.ts
@@ -206,12 +206,6 @@ export const appIT = {
       'nodata':
         "Non ci sono tracce preferite, clicca sull'icona cuore di una traccia per aggiungerla a questa lista",
       'title': 'Preferiti',
-      'tabs': {
-        'tracks': 'Sentieri',
-        'layers': 'Layers',
-      },
-      'nodataLayers':
-        "Non ci sono cammini preferiti, clicca sull'icona cuore di un cammino per aggiungerlo a questa lista",
     },
     'home': {
       'button': 'Scegli un punto di partenza',
@@ -563,6 +557,10 @@ export const appIT = {
       },
     },
   },
+  'Layers': 'Layers',
+  'Sentieri': 'Sentieri',
+  'Non ci sono cammini preferiti, clicca sull\'icona cuore di un cammino per aggiungerlo a questa lista':
+    'Non ci sono cammini preferiti, clicca sull\'icona cuore di un cammino per aggiungerlo a questa lista',
   'services': {
     'geolocation': {
       'notification': {

--- a/core/src/assets/i18n/pr.ts
+++ b/core/src/assets/i18n/pr.ts
@@ -200,7 +200,12 @@ export const appPR = {
     },
     'favourites': {
       'nodata': 'Não há rotas favoritas, clique no ícone de coração de uma rota para adicioná-la a esta lista',
-      'title': 'Favoritos'
+      'title': 'Favoritos',
+      'tabs': {
+        'tracks': 'Trilhas',
+        'layers': 'Layers'
+      },
+      'nodataLayers': 'Não há caminhos favoritos, clique no ícone de coração de um caminho para adicioná-lo a esta lista'
     },
     'home': {
       'button': 'Escolha um ponto de partida',
@@ -597,6 +602,8 @@ export const appPR = {
   'Ti trovi qui': 'Você está aqui',
   'Salva Waypoint': 'Salvar ponto de referência',
   'Salva Traccia': 'Salvar rota',
+  'Impossibile caricare i cammini preferiti, riprova':
+    'Não foi possível carregar os caminhos favoritos, tente novamente',
   'privacy': {
     'agree': {
       'title': 'Processamento de dados',

--- a/core/src/assets/i18n/pr.ts
+++ b/core/src/assets/i18n/pr.ts
@@ -200,12 +200,7 @@ export const appPR = {
     },
     'favourites': {
       'nodata': 'Não há rotas favoritas, clique no ícone de coração de uma rota para adicioná-la a esta lista',
-      'title': 'Favoritos',
-      'tabs': {
-        'tracks': 'Trilhas',
-        'layers': 'Layers'
-      },
-      'nodataLayers': 'Não há caminhos favoritos, clique no ícone de coração de um caminho para adicioná-lo a esta lista'
+      'title': 'Favoritos'
     },
     'home': {
       'button': 'Escolha um ponto de partida',
@@ -548,6 +543,10 @@ export const appPR = {
       'content': 'Caminhar na natureza e, mais amplamente, atividades ao ar livre, são atividades potencialmente perigosas: antes de partir para uma excursão, certifique-se de que você tem o conhecimento e as habilidades para fazê-lo. Se você não tiver certeza, procure especialistas locais que possam ajudá-lo, sugerir e apoiar no planejamento e desenvolvimento de suas atividades. Os dados apresentados neste APLICATIVO não podem garantir totalmente a viabilidade sem riscos da rota: podem ter ocorrido mudanças, até mesmo significativas, desde a última verificação da rota. Portanto, é essencial que aqueles que pretendem desenvolver atividades avaliem cuidadosamente a possibilidade de prosseguir com base nas sugestões e conselhos contidos neste APLICATIVO, com base em sua experiência, condições meteorológicas (mesmo dos dias anteriores) e uma avaliação feita no local no início do desenvolvimento da atividade. A empresa Webmapp S.r.l. não oferece garantias para a segurança dos locais descritos e não assume qualquer responsabilidade por possíveis danos causados pelo desenvolvimento das atividades descritas.'
     }
   },
+  'Layers': 'Layers',
+  'Sentieri': 'Trilhas',
+  'Non ci sono cammini preferiti, clicca sull\'icona cuore di un cammino per aggiungerlo a questa lista':
+    'Não há caminhos favoritos, clique no ícone de coração de um caminho para adicioná-lo a esta lista',
   'services': {
     'geolocation': {
       'notification': {

--- a/core/src/assets/i18n/sq.ts
+++ b/core/src/assets/i18n/sq.ts
@@ -200,7 +200,12 @@ export const appSQ = {
     },
     'favourites': {
       'nodata': 'Nuk ka gjurmë të preferuara, kliko mbi ikonën e zemrës së një gjurme për ta shtuar në këtë listë',
-      'title': 'Të preferuarat'
+      'title': 'Të preferuarat',
+      'tabs': {
+        'tracks': 'Shtigjet',
+        'layers': 'Layers'
+      },
+      'nodataLayers': 'Nuk ka shtigje të preferuara, kliko mbi ikonën e zemrës së një shtegu për ta shtuar në këtë listë'
     },
     'home': {
       'button': 'Zgjidh një pikë nisjeje',
@@ -592,6 +597,8 @@ export const appSQ = {
   'Ti trovi qui': 'Je këtu',
   'Salva Waypoint': 'Ruaj pikën e rrugës',
   'Salva Traccia': 'Ruaj gjurmën',
+  'Impossibile caricare i cammini preferiti, riprova':
+    'Nuk u arrit të ngarkoheshin shtigjet e preferuara, provo përsëri',
   'privacy': {
     'agree': {
       'title': 'Përpunimi i të dhënave',

--- a/core/src/assets/i18n/sq.ts
+++ b/core/src/assets/i18n/sq.ts
@@ -200,12 +200,7 @@ export const appSQ = {
     },
     'favourites': {
       'nodata': 'Nuk ka gjurmë të preferuara, kliko mbi ikonën e zemrës së një gjurme për ta shtuar në këtë listë',
-      'title': 'Të preferuarat',
-      'tabs': {
-        'tracks': 'Shtigjet',
-        'layers': 'Layers'
-      },
-      'nodataLayers': 'Nuk ka shtigje të preferuara, kliko mbi ikonën e zemrës së një shtegu për ta shtuar në këtë listë'
+      'title': 'Të preferuarat'
     },
     'home': {
       'button': 'Zgjidh një pikë nisjeje',
@@ -543,6 +538,10 @@ export const appSQ = {
       'content': "Ecja në natyrë dhe, më gjerë, aktivitetet në natyrë, janë aktivitete potencialisht të rrezikshme: para se të niseni për një ekskursion sigurohuni që keni njohuritë dhe aftësitë për ta bërë këtë. Nëse nuk jeni të sigurt, drejtohuni tek ekspertët lokalë që mund t'ju ndihmojnë, sugjerojnë dhe mbështesin në planifikimin dhe zhvillimin e aktiviteteve tuaja. Të dhënat e paraqitura në këtë APLIKACION nuk mund të garantojnë plotësisht përshkueshmërinë pa rreziqe të rrugës: mund të kenë ndodhur ndryshime, edhe të rëndësishme, që nga verifikimi i fundit i rrugës. Prandaj është thelbësore që ata që synojnë të zhvillojnë aktivitete të vlerësojnë me kujdes mundësinë e vazhdimit bazuar në sugjerimet dhe këshillat e përmbajtura në këtë APLIKACION, bazuar në përvojën e tyre, kushtet meteorologjike (edhe të ditëve të mëparshme) dhe një vlerësim të bërë në terren në fillim të zhvillimit të aktivitetit. Shoqëria Webmapp S.r.l. nuk ofron garanci për sigurinë e vendeve të përshkruara, dhe nuk merr asnjë përgjegjësi për dëmet e mundshme të shkaktuara nga zhvillimi i aktiviteteve të përshkruara."
     }
   },
+  'Layers': 'Layers',
+  'Sentieri': 'Shtigjet',
+  'Non ci sono cammini preferiti, clicca sull\'icona cuore di un cammino per aggiungerlo a questa lista':
+    'Nuk ka shtigje të preferuara, kliko mbi ikonën e zemrës së një shtegu për ta shtuar në këtë listë',
   'services': {
     'geolocation': {
       'notification': {

--- a/core/tsconfig.spec.json
+++ b/core/tsconfig.spec.json
@@ -13,6 +13,7 @@
   ],
   "include": [
     "src/app/services/**/*.spec.ts",
+    "src/app/pages/favourites/**/*.spec.ts",
     "src/**/*.d.ts"
   ]
 }

--- a/docs/features/8176-salva-cammino-nei-preferiti/notes.md
+++ b/docs/features/8176-salva-cammino-nei-preferiti/notes.md
@@ -23,6 +23,10 @@ Vedi `wm-core/docs/features/8176-salva-cammino-nei-preferiti/notes.md`: le class
 - **Rinominate le etichette**: "Cammini" → "Layers" (stessa parola in tutte le 7 lingue, scelta deliberata del developer, non tradotta) e "Tracce" → "Sentieri"/equivalente per lingua (riusati gli stessi termini già usati per il badge conteggio "Sentiero"/"Sentieri" in wm-core, per coerenza terminologica nell'app).
 - **Aggiunto `trackBy`** su `FavouritesLayersComponent` (vedi wm-core/notes.md per il dettaglio).
 
+## Terza revisione — convenzione i18n corretta a mano dal developer
+
+Il developer ha modificato `favourites.page.html` sostituendo le chiavi "a percorso" (`pages.favourites.tabs.tracks`/`.layers`) con chiavi flat testo-semplice (`'Layers'`, `'Sentieri'`) — convenzione corretta del progetto (il testo italiano stesso è la chiave), non quella nidificata usata per errore in questa feature. Ho trovato e corretto lo stesso problema in `favourites-layers.component.html` (`pages.favourites.nodataLayers` → chiave flat col testo completo del messaggio). Rimosse le chiavi nidificate `tabs`/`nodataLayers` da `pages.favourites` in tutti i 7 file i18n, aggiunte le corrispondenti chiavi flat a livello root (`'Layers'`, `'Sentieri'`, e il messaggio di stato vuoto) con gli stessi valori tradotti già presenti. Le chiavi pre-esistenti `pages.favourites.title`/`pages.favourites.nodata` (non introdotte da questa feature) sono state lasciate invariate, fuori scope.
+
 ## Follow-up
 
 - Nessuno specifico a questo repo oltre a quanto già tracciato in wm-core.

--- a/docs/features/8176-salva-cammino-nei-preferiti/notes.md
+++ b/docs/features/8176-salva-cammino-nei-preferiti/notes.md
@@ -1,0 +1,28 @@
+> Ticket: oc:8176
+
+# Notes — Salva cammino nei preferiti (webmapp-app)
+
+## Deviazioni dal piano
+
+**`FavouritesLayersComponent` aggiornato dopo la verifica visiva del developer** (vedi anche `wm-core/docs/features/8176-salva-cammino-nei-preferiti/notes.md` per il dettaglio completo, la decisione principale vive lì perché `wm-layer-box` è un componente wm-core):
+- `wm-layer-box` nel tab "Cammini" ora usa `[favoriteInteractive]="true"` — necessario perché di default il cuoricino di `wm-layer-box` è di sola lettura (redesign richiesto per le card in Home), ma nel tab Preferiti serve poter rimuovere un preferito direttamente dalla lista.
+- Aggiunto `(clickEVT)="openLayer(box.layer)"` sul box, che chiama il nuovo metodo `UrlHandlerService.setLayer(layer)` (wm-core) — prima il click sulla card nel tab Cammini non faceva nulla, ora apre il layer sulla mappa come dalla Home.
+
+## Bug trovati
+
+Vedi `wm-core/docs/features/8176-salva-cammino-nei-preferiti/notes.md`: le classi icona `webmapp-icon-heart`/`webmapp-icon-heart-outline` usate inizialmente non esistevano nell'icon font del progetto — il cuoricino non era mai visibile. Non è un bug di questo repo, ma impatta lo stesso componente riusato qui (`wm-layer-box`).
+
+## Review formale (`wm-skills:wm-review-ticket`) — findings corretti in questo repo
+
+- **[blocker] `openLayer()` poteva non navigare affatto** — `UrlHandlerService.setLayer()` (wm-core) usava `updateURL()`, che naviga solo se i query param cambiano rispetto a quelli correnti. Se l'utente aveva già aperto lo stesso layer dalla Home in una navigazione precedente, il query param `layer` risultava invariato e il click sulla card nel tab Cammini non navigava affatto verso `/map`. Corretto (in wm-core) usando `changeURL()`, basato sul path corrente — stesso meccanismo già usato da `favourites.page.ts` per le tracce preferite (`open()` → `changeURL('map', {track:id})`).
+- **[cleanup] `.webmapp-favourites-nodata` non si applicava nel tab Cammini** — vedi `wm-core/notes.md` per il dettaglio (bug di `ViewEncapsulation`), fix in `favourites-layers.component.scss` di questo repo.
+
+## Seconda revisione tab (su richiesta esplicita del developer)
+
+- **Ordine invertito**: il segmento "Layers" (ex "Cammini") ora precede "Sentieri" (ex "Tracce") in `favourites.page.html` — solo ordine visivo dei due `ion-segment-button`, `selectedSegment` di default resta `'tracks'` (comportamento Sentieri invariato, come richiesto in origine).
+- **Rinominate le etichette**: "Cammini" → "Layers" (stessa parola in tutte le 7 lingue, scelta deliberata del developer, non tradotta) e "Tracce" → "Sentieri"/equivalente per lingua (riusati gli stessi termini già usati per il badge conteggio "Sentiero"/"Sentieri" in wm-core, per coerenza terminologica nell'app).
+- **Aggiunto `trackBy`** su `FavouritesLayersComponent` (vedi wm-core/notes.md per il dettaglio).
+
+## Follow-up
+
+- Nessuno specifico a questo repo oltre a quanto già tracciato in wm-core.

--- a/docs/features/8176-salva-cammino-nei-preferiti/overview.md
+++ b/docs/features/8176-salva-cammino-nei-preferiti/overview.md
@@ -1,0 +1,41 @@
+> Ticket: oc:8176
+
+# Salva cammino nei preferiti — webmapp-app
+
+## Cosa cambia
+
+**Scoperta chiave emersa durante l'analisi (corregge lo scope originale del ticket):** la sezione "I miei preferiti" per le tracce (`EcTrack`) **esiste già in produzione** — un tab "Favourites" nella tab bar principale (`pages/tabs/tabs.page.html`, icona cuore, visibile quando `confAUTHEnable && isLogged`), una pagina `favourites.page.ts` funzionante (chiama gli stessi endpoint `EcTrackController` di wm-package), e un cuoricino già attivo su `map-track-card.component`. Il ticket originale la elencava erroneamente come "out of scope / UI non implementata".
+
+Questa feature estende `FavouritesPage` da lista singola (solo tracce) a **vista a due tab**: "Tracce" (comportamento invariato, sempre visibile secondo la condizione esistente) e "Cammini" (nuovo, visibile **solo se `OPTIONS.showFavorites=true`**). Il tab bar principale e la sua condizione di visibilità (`confAUTHEnable && isLogged`) restano invariati — `showFavorites` non tocca la visibilità dell'intero tab "Favourites", solo del sotto-tab "Cammini" al suo interno.
+
+Il tab "Cammini" riusa il componente `wm-layer-box` (wm-core) per il rendering, popolato dalla stessa chiamata `GET /api/layer/favorite/list` (wm-package) usata dal cuoricino in wm-core — stesso servizio condiviso, nessuna duplicazione di cache.
+
+**UX (da `ui-ux-pro-max`):** per il selettore tra i due tab dentro `FavouritesPage`, usare `ion-segment` (cambio di vista in-page) e non `ion-tabs` annidati — i tab Ionic sono pensati per route indipendenti con propria history; usarli qui romperebbe l'aspettativa dell'utente sul comportamento del tasto "indietro" (la navigazione a "Tracce"/"Cammini" non deve generare voci nella cronologia).
+
+## Perché
+
+Il cliente vuole salvare i cammini di interesse per ritrovarli facilmente — la stessa capacità già disponibile oggi per le tracce, estesa ai layer. Vedi overview `wm-core` e `wm-package` per i dettagli tecnici cross-repo.
+
+## Requisiti
+
+- [ ] `FavouritesPage` ristrutturata con `ion-segment` a due voci: "Tracce" (contenuto/logica esistente invariata) e "Cammini" (nuovo)
+- [ ] Tab "Cammini" visibile solo se `OPTIONS.showFavorites=true` (letto da `@wm-core/store/conf/conf.selector.ts`, nuovo selettore `confOPTIONSShowFavorites`)
+- [ ] Tab "Cammini" popolato riusando `wm-layer-box` (wm-core) e il servizio condiviso di cache preferiti layer (vedi overview wm-core)
+- [ ] Tab "Cammini": stato vuoto (stesso pattern `pages.favourites.nodata` del tab Tracce) e stato di errore su fetch fallita
+- [ ] i18n: nuove chiavi per le label dei due segmenti, in tutte le 7 lingue (default italiano), in `core/src/assets/i18n/*`
+
+## Rischi
+
+- **Il ticket originale descriveva erroneamente i preferiti-tracce come "non implementati"**: qualunque stima o comunicazione col cliente basata sul testo originale del ticket va aggiornata — il lavoro reale è "estendere a due tab", non "costruire la sezione preferiti da zero"
+- Vedi rischio di cache disallineata cuoricino/lista e assenza di paginazione in overview wm-core
+
+## Out of scope
+
+- Redesign della UX esistente delle tracce preferite (card, comportamento tab "Tracce")
+- Preferiti su `EcPoi`
+
+## Moduli toccati
+
+- `core/src/app/pages/favourites/favourites.page.{ts,html,scss}`
+- `core/src/app/pages/favourites/favourites.module.ts` / `favourites-routing.module.ts` (se serve nuovo import di `wm-layer-box`)
+- `core/src/assets/i18n/{it,en,de,es,fr,pr,sq}.ts`

--- a/docs/features/8176-salva-cammino-nei-preferiti/plan.md
+++ b/docs/features/8176-salva-cammino-nei-preferiti/plan.md
@@ -1,0 +1,477 @@
+# Salva cammino nei preferiti — webmapp-app Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+> Ticket: oc:8176
+
+**Goal:** Trasformare `FavouritesPage` (oggi solo tracce) in una vista a due segmenti — "Tracce" (invariato) e "Cammini" (nuovo, condizionato a `OPTIONS.show_favorites`) — riusando `wm-layer-box` e `LayerFavoriteService` da wm-core.
+
+**Architecture:** `ion-segment` in-page (non `ion-tabs` annidati, per non introdurre voci di history indesiderate). Il segmento "Tracce" mantiene il comportamento e i binding esistenti immutati. Il segmento "Cammini" chiama `LayerFavoriteService.getFavorites()` (wm-core, import diretto via `@wm-core/services/layer-favorite.service`, stesso pattern già in uso per `isLogged` da `auth.selectors`) e si sottoscrive a `favorites$` per restare reattivo se un preferito viene rimosso dal cuoricino dentro la lista stessa.
+
+**Tech Stack:** Angular 20 (standalone: false), Ionic 8 (`ion-segment`), Karma/Jasmine.
+
+## Global Constraints
+
+- Il comportamento e i binding del segmento "Tracce" (paginazione, `remove()`, `nodata`) restano **invariati** — nessuna regressione
+- Il segmento "Cammini" è visibile solo se `confOPTIONSShowFavorites` (selettore da `@wm-core/store/conf/conf.selector`, introdotto nel piano wm-core) è `true`
+- `ILAYER.id` è `string` — nessuna coercizione numerica nei confronti
+- Nessuna migration, nessun nuovo endpoint in questo repo — tutta la logica di rete/cache vive in `LayerFavoriteService` (wm-core)
+
+---
+
+### Task 1: `ion-segment` Tracce/Cammini in `FavouritesPage`
+
+**Files:**
+- Modify: `core/src/app/pages/favourites/favourites.page.ts`
+- Modify: `core/src/app/pages/favourites/favourites.page.html`
+- Modify: `core/src/app/pages/favourites/favourites.page.scss`
+- Test: `core/src/app/pages/favourites/favourites.page.spec.ts` (nuovo — solo la logica del segmento, non l'intero componente)
+
+**Interfaces:**
+- Consumes: `confOPTIONSShowFavorites` (da `@wm-core/store/conf/conf.selector`, wm-core Task 1)
+- Produces: `selectedSegment: 'tracks' | 'layers'` (property pubblica), consumato dal Task 2 per condizionare il caricamento dei preferiti layer
+
+- [ ] **Step 1: Scrivi il test per il default del segmento e la visibilità condizionata**
+
+```typescript
+import {Store} from '@ngrx/store';
+import {of} from 'rxjs';
+import {GeohubService} from 'src/app/services/geohub.service';
+import {UrlHandlerService} from '@wm-core/services/url-handler.service';
+
+import {FavouritesPage} from './favourites.page';
+
+describe('FavouritesPage — segmento Tracce/Cammini (oc:8176)', () => {
+  function createPage(showFavorites: boolean): FavouritesPage {
+    const storeSpy = jasmine.createSpyObj<Store>('Store', ['select']);
+    storeSpy.select.and.returnValue(of(showFavorites));
+    const geoHubSvcSpy = jasmine.createSpyObj<GeohubService>('GeohubService', [
+      'getFavouriteTracks',
+      'setFavouriteTrack',
+    ]);
+    geoHubSvcSpy.getFavouriteTracks.and.resolveTo([]);
+    const urlHandlerSvcSpy = jasmine.createSpyObj<UrlHandlerService>('UrlHandlerService', [
+      'changeURL',
+    ]);
+
+    return new FavouritesPage(geoHubSvcSpy, storeSpy, urlHandlerSvcSpy);
+  }
+
+  it('parte con il segmento "tracks" selezionato', () => {
+    const page = createPage(true);
+    expect(page.selectedSegment).toBe('tracks');
+  });
+
+  it('espone showLayersSegment$ come true quando show_favorites è true', done => {
+    const page = createPage(true);
+    page.showLayersSegment$.subscribe(v => {
+      expect(v).toBe(true);
+      done();
+    });
+  });
+
+  it('espone showLayersSegment$ come false quando show_favorites è false', done => {
+    const page = createPage(false);
+    page.showLayersSegment$.subscribe(v => {
+      expect(v).toBe(false);
+      done();
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Esegui il test per verificare che fallisca**
+
+Run: `ng test --include='**/favourites.page.spec.ts'`
+Expected: FAIL — `selectedSegment`/`showLayersSegment$` non esistono sulla classe
+
+- [ ] **Step 3: Aggiorna `favourites.page.ts`**
+
+```typescript
+import {Component, OnInit, ViewChild} from '@angular/core';
+import {IonInfiniteScroll} from '@ionic/angular';
+import {GeohubService} from 'src/app/services/geohub.service';
+import {NavigationExtras, Router} from '@angular/router';
+import {BehaviorSubject, Observable} from 'rxjs';
+import {select, Store} from '@ngrx/store';
+import {isLogged} from '@wm-core/store/auth/auth.selectors';
+import {confOPTIONSShowFavorites} from '@wm-core/store/conf/conf.selector';
+import {Feature, LineString} from 'geojson';
+import {UrlHandlerService} from '@wm-core/services/url-handler.service';
+
+@Component({
+  standalone: false,
+  selector: 'webmapp-favourites',
+  templateUrl: './favourites.page.html',
+  styleUrls: ['./favourites.page.scss'],
+})
+export class FavouritesPage implements OnInit {
+  private page: number = 0;
+
+  @ViewChild(IonInfiniteScroll) infiniteScroll: IonInfiniteScroll;
+
+  isLogged$: Observable<boolean> = this._store.pipe(select(isLogged));
+  showLayersSegment$: Observable<boolean> = this._store.select(confOPTIONSShowFavorites);
+  selectedSegment: 'tracks' | 'layers' = 'tracks';
+  tracks$: BehaviorSubject<Feature<LineString>[]> = new BehaviorSubject<Feature<LineString>[]>(
+    null,
+  );
+
+  constructor(
+    private _geoHubService: GeohubService,
+    private _store: Store,
+    private _urlHandlerSvc: UrlHandlerService,
+  ) {}
+
+  async ngOnInit() {
+    this.doRefresh(null);
+  }
+
+  onSegmentChange(segment: 'tracks' | 'layers'): void {
+    this.selectedSegment = segment;
+  }
+
+  async doRefresh(event) {
+    this.page = 0;
+    this.tracks$.next(await this._geoHubService.getFavouriteTracks());
+    if (event) {
+      event.target.complete();
+    }
+  }
+
+  async ionViewDidEnter() {
+    this.doRefresh(null);
+  }
+
+  async loadData(event) {
+    this.tracks$.next([
+      ...this.tracks$.value,
+      ...(await this._geoHubService.getFavouriteTracks(++this.page)),
+    ]);
+
+    event.target.complete();
+  }
+
+  open(track: Feature<LineString>) {
+    const clickedFeatureId = track.properties.id ?? null;
+    this._urlHandlerSvc.changeURL('map', {track: clickedFeatureId});
+  }
+
+  async remove(track: Feature<LineString>) {
+    await this._geoHubService.setFavouriteTrack(track.properties.id, false);
+    const idx = this.tracks$.value.findIndex(x => x.properties.id == track.properties.id);
+    const currentTracks = this.tracks$.value;
+    currentTracks.splice(idx, 1);
+    this.tracks$.next([...currentTracks]);
+  }
+}
+```
+
+(Unico cambiamento rispetto all'originale: aggiunti `showLayersSegment$`, `selectedSegment`, `onSegmentChange()` e l'import di `confOPTIONSShowFavorites` — tutto il resto della classe è invariato.)
+
+- [ ] **Step 4: Aggiorna `favourites.page.html`**
+
+```html
+<ion-header>
+  <ion-toolbar class="webmapp-favourites-header-toolbar-header">
+    <ion-title mode="md" class="webmapp-favourites-header-toolbar-title">
+      {{'pages.favourites.title' | wmtrans}}
+    </ion-title>
+  </ion-toolbar>
+  <ion-toolbar *ngIf="showLayersSegment$|async">
+    <ion-segment [value]="selectedSegment" (ionChange)="onSegmentChange($event.detail.value)">
+      <ion-segment-button value="tracks">
+        <ion-label>{{'pages.favourites.tabs.tracks' | wmtrans}}</ion-label>
+      </ion-segment-button>
+      <ion-segment-button value="layers">
+        <ion-label>{{'pages.favourites.tabs.layers' | wmtrans}}</ion-label>
+      </ion-segment-button>
+    </ion-segment>
+  </ion-toolbar>
+</ion-header>
+
+<ion-content>
+  <ion-refresher slot="fixed" (ionRefresh)="doRefresh($event)" *ngIf="selectedSegment === 'tracks'">
+    <ion-refresher-content></ion-refresher-content>
+  </ion-refresher>
+  <ng-container *ngIf="isLogged$|async;else nologged">
+    <ng-container *ngIf="selectedSegment === 'tracks'">
+      <ng-container *ngIf="tracks$|async as tracks">
+        <ion-label class="webmapp-favourites-nodata" *ngIf="!tracks || !tracks.length"
+          >{{'pages.favourites.nodata' | wmtrans}}</ion-label
+        >
+        <ion-list>
+          <webmapp-card-track
+            *ngFor="let track of tracks"
+            [track]="track"
+            (open)="open($event)"
+            (remove)="remove($event)"
+          >
+          </webmapp-card-track> </ion-list
+      ></ng-container>
+    </ng-container>
+
+    <webmapp-favourites-layers *ngIf="selectedSegment === 'layers'"></webmapp-favourites-layers>
+  </ng-container>
+  <ng-template #nologged>
+    <ion-label class="webmapp-favourites-nodata">
+      {{'non sei loggato. puoi loggare da'|wmtrans}}
+      <ion-button [routerLink]="['/profile']">{{'qui'|wmtrans}}</ion-button></ion-label
+    >
+  </ng-template>
+
+  <ion-infinite-scroll
+    *ngIf="selectedSegment === 'tracks'"
+    threshold="100px"
+    (ionInfinite)="loadData($event)"
+  >
+    <ion-infinite-scroll-content loadingSpinner="bubbles" loadingText="Loading more data...">
+    </ion-infinite-scroll-content>
+  </ion-infinite-scroll>
+</ion-content>
+```
+
+`webmapp-favourites-layers` è un nuovo componente creato nel Task 2 — dichiaralo qui come riferimento anticipato, il template non compila finché il Task 2 non lo crea (atteso: questo task da solo lascia un errore di compilazione sul tag sconosciuto se eseguito isolatamente in produzione; è comunque corretto seguire l'ordine TDD step-by-step, il Task 2 lo risolve subito dopo).
+
+- [ ] **Step 5: Aggiungi lo stile del segmento**
+
+In `favourites.page.scss`, aggiungi in coda:
+
+```scss
+ion-segment {
+  --background: transparent;
+}
+```
+
+- [ ] **Step 6: Esegui il test per verificare che passi**
+
+Run: `ng test --include='**/favourites.page.spec.ts'`
+Expected: PASS (3 test)
+
+- [ ] **Step 7: Aggiungi le chiavi i18n**
+
+In `core/src/assets/i18n/it.ts`, dentro `'pages': {'favourites': {...}}`, aggiungi:
+
+```typescript
+    'favourites': {
+      'nodata':
+        "Non ci sono tracce preferite, clicca sull'icona cuore di una traccia per aggiungerla a questa lista",
+      'title': 'Preferiti',
+      'tabs': {
+        'tracks': 'Tracce',
+        'layers': 'Cammini',
+      },
+      'nodataLayers':
+        "Non ci sono cammini preferiti, clicca sull'icona cuore di un cammino per aggiungerlo a questa lista",
+    },
+```
+
+Ripeti la stessa struttura chiave (`tabs.tracks`, `tabs.layers`, `nodataLayers`) nei restanti 6 file (`en.ts`, `de.ts`, `es.ts`, `fr.ts`, `pr.ts`, `sq.ts`), con i valori tradotti nella lingua corrispondente (es. `en.ts`: `'tracks': 'Tracks', 'layers': 'Paths'`).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add core/src/app/pages/favourites/favourites.page.ts core/src/app/pages/favourites/favourites.page.html core/src/app/pages/favourites/favourites.page.scss core/src/app/pages/favourites/favourites.page.spec.ts core/src/assets/i18n/
+git commit -m "feat(oc:8176): add tracks/layers segment scaffold to FavouritesPage"
+```
+
+---
+
+### Task 2: Componente `webmapp-favourites-layers`
+
+**Files:**
+- Create: `core/src/app/pages/favourites/favourites-layers/favourites-layers.component.ts`
+- Create: `core/src/app/pages/favourites/favourites-layers/favourites-layers.component.html`
+- Create: `core/src/app/pages/favourites/favourites-layers/favourites-layers.component.scss`
+- Modify: `core/src/app/pages/favourites/favourites.module.ts` (dichiarazione componente + import `BoxModule`)
+- Test: `core/src/app/pages/favourites/favourites-layers/favourites-layers.component.spec.ts` (nuovo)
+
+**Interfaces:**
+- Consumes: `LayerFavoriteService` (wm-core Task 2: `.getFavorites()`, `.favorites$`), `ILAYER`/`ILAYERBOX` (`@wm-core/types/config`)
+- Produces: `<webmapp-favourites-layers>`, usato dal Task 1 di questo repo
+
+- [ ] **Step 1: Scrivi i test per stato caricamento/vuoto/popolato/errore**
+
+```typescript
+import {LayerFavoriteService} from '@wm-core/services/layer-favorite.service';
+import {ILAYER} from '@wm-core/types/config';
+import {of, throwError} from 'rxjs';
+
+import {FavouritesLayersComponent} from './favourites-layers.component';
+
+describe('FavouritesLayersComponent (oc:8176)', () => {
+  const fakeLayer: ILAYER = {id: '3', title: 'Cammino preferito'} as any;
+
+  function createComponent(
+    favorites: ILAYER[],
+    getFavoritesError = false,
+  ): FavouritesLayersComponent {
+    const favoriteSvcSpy = jasmine.createSpyObj<LayerFavoriteService>('LayerFavoriteService', [
+      'getFavorites',
+    ]);
+    (favoriteSvcSpy as any).favorites$ = of(favorites);
+    if (getFavoritesError) {
+      favoriteSvcSpy.getFavorites.and.rejectWith(new Error('network error'));
+    } else {
+      favoriteSvcSpy.getFavorites.and.resolveTo(favorites);
+    }
+
+    return new FavouritesLayersComponent(favoriteSvcSpy);
+  }
+
+  it('espone loadError = true se getFavorites fallisce', async () => {
+    const component = createComponent([], true);
+    await component.ngOnInit();
+    expect(component.loadError).toBeTrue();
+  });
+
+  it('espone loadError = false e la lista se getFavorites va a buon fine', async () => {
+    const component = createComponent([fakeLayer]);
+    await component.ngOnInit();
+    expect(component.loadError).toBeFalse();
+
+    let layers: ILAYER[];
+    component.layers$.subscribe(v => (layers = v));
+    expect(layers).toEqual([fakeLayer]);
+  });
+
+  it('avvolge ogni layer in un box di tipo layer per wm-layer-box', async () => {
+    const component = createComponent([fakeLayer]);
+    await component.ngOnInit();
+
+    let boxes: any[];
+    component.layerBoxes$.subscribe(v => (boxes = v));
+    expect(boxes).toEqual([{box_type: 'layer', title: fakeLayer.title, layer: fakeLayer}]);
+  });
+});
+```
+
+- [ ] **Step 2: Esegui i test per verificare che falliscano**
+
+Run: `ng test --include='**/favourites-layers.component.spec.ts'`
+Expected: FAIL — modulo `./favourites-layers.component` non trovato
+
+- [ ] **Step 3: Crea il componente**
+
+```typescript
+import {ChangeDetectionStrategy, Component, OnInit} from '@angular/core';
+import {LayerFavoriteService} from '@wm-core/services/layer-favorite.service';
+import {ILAYER, ILAYERBOX} from '@wm-core/types/config';
+import {Observable} from 'rxjs';
+import {map} from 'rxjs/operators';
+
+@Component({
+  standalone: false,
+  selector: 'webmapp-favourites-layers',
+  templateUrl: './favourites-layers.component.html',
+  styleUrls: ['./favourites-layers.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class FavouritesLayersComponent implements OnInit {
+  layers$: Observable<ILAYER[]> = this._layerFavoriteSvc.favorites$;
+  layerBoxes$: Observable<ILAYERBOX[]> = this.layers$.pipe(
+    map(layers => layers.map(layer => ({box_type: 'layer' as const, title: layer.title, layer}))),
+  );
+  loadError = false;
+  loading = true;
+
+  constructor(private _layerFavoriteSvc: LayerFavoriteService) {}
+
+  async ngOnInit(): Promise<void> {
+    try {
+      await this._layerFavoriteSvc.getFavorites();
+      this.loadError = false;
+    } catch {
+      this.loadError = true;
+    } finally {
+      this.loading = false;
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Crea il template**
+
+```html
+<ion-label class="webmapp-favourites-nodata" *ngIf="loadError">
+  {{'Impossibile caricare i cammini preferiti, riprova' | wmtrans}}
+</ion-label>
+
+<ng-container *ngIf="!loadError">
+  <ng-container *ngIf="layerBoxes$|async as boxes">
+    <ion-label class="webmapp-favourites-nodata" *ngIf="!loading && !boxes.length">
+      {{'pages.favourites.nodataLayers' | wmtrans}}
+    </ion-label>
+    <ion-list>
+      <wm-layer-box *ngFor="let box of boxes" [data]="box"></wm-layer-box>
+    </ion-list>
+  </ng-container>
+</ng-container>
+```
+
+- [ ] **Step 5: Crea lo stile (vuoto, eredita da `favourites.page.scss`)**
+
+```scss
+:host {
+  display: block;
+}
+```
+
+- [ ] **Step 6: Registra il componente nel modulo**
+
+In `core/src/app/pages/favourites/favourites.module.ts`:
+
+```typescript
+import {NgModule} from '@angular/core';
+import {CommonModule} from '@angular/common';
+import {FormsModule} from '@angular/forms';
+
+import {IonicModule} from '@ionic/angular';
+
+import {FavouritesPageRoutingModule} from './favourites-routing.module';
+
+import {FavouritesPage} from './favourites.page';
+import {FavouritesLayersComponent} from './favourites-layers/favourites-layers.component';
+import {CardsModule} from 'src/app/components/cards/cards.module';
+import {WmPipeModule} from '@wm-core/pipes/pipe.module';
+import {BoxModule} from 'src/app/components/box/box.module';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    FormsModule,
+    IonicModule,
+    FavouritesPageRoutingModule,
+    WmPipeModule,
+    CardsModule,
+    BoxModule,
+  ],
+  declarations: [FavouritesPage, FavouritesLayersComponent],
+})
+export class FavouritesPageModule {}
+```
+
+- [ ] **Step 7: Esegui i test per verificare che passino**
+
+Run: `ng test --include='**/favourites-layers.component.spec.ts'`
+Expected: PASS (3 test)
+
+- [ ] **Step 8: Esegui anche il test del Task 1 per verificare che l'intera pagina compili ora**
+
+Run: `ng test --include='**/favourites.page.spec.ts'`
+Expected: PASS (3 test, invariato)
+
+- [ ] **Step 9: Aggiungi la chiave i18n per l'errore di caricamento**
+
+In tutti e 7 i file `core/src/assets/i18n/{it,en,de,es,fr,pr,sq}.ts`, aggiungi (a livello root, stesso pattern chiave-italiana delle altre chiavi in questi file):
+
+```typescript
+  'Impossibile caricare i cammini preferiti, riprova': 'Impossibile caricare i cammini preferiti, riprova', // it — valore tradotto per le altre lingue
+```
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add core/src/app/pages/favourites/ core/src/assets/i18n/
+git commit -m "feat(oc:8176): add favourites-layers component wired to LayerFavoriteService"
+```


### PR DESCRIPTION
## Summary
- Restructures `FavouritesPage` (previously tracks-only) into two `ion-segment` tabs: "Layers" (new) and "Sentieri" (previously "Tracce", behavior unchanged). "Layers" is shown first, gated by `OPTIONS.showFavorites`.
- New `FavouritesLayersComponent`, reusing `wm-layer-box`/`LayerFavoriteService` from wm-core to list/remove favorite layers, with navigation to the map on tap.
- Bumps `wm-core`/`wm-types` submodule pointers.

## Test plan
- [x] `ng test -c ci` — 13/13 passing
- [x] Depends on wm-core PR #180 and wm-types PR #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)