### PR TITLE
fix: inject shardName alongside appId for E2E CI environment

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -36,12 +36,14 @@ jobs:
           if [ ! -f posthog.json ]; then
             echo '{ "POSTHOG_KEY": "", "POSTHOG_HOST": "" }' > posthog.json
           fi
-      - name: Inject appId in environment.ts
+      - name: Inject appId and shardName in environment.ts
         run: |
           sed -i '0,/appId: [0-9]\+/s//appId: 52/' core/src/environments/environment.ts
-      - name: Verify appId injection
+          sed -i "0,/shardName: '[a-zA-Z0-9]\+'/s//shardName: 'geohub'/" core/src/environments/environment.ts
+      - name: Verify appId and shardName injection
         run: |
           grep -q 'appId: 52' core/src/environments/environment.ts || (echo "ERROR: appId injection failed" && exit 1)
+          grep -q "shardName: 'geohub'" core/src/environments/environment.ts || (echo "ERROR: shardName injection failed" && exit 1)
       - name: Setup Chrome
         uses: browser-actions/setup-chrome@v1
       - name: Run Cypress E2E


### PR DESCRIPTION
## Summary
- Da 6+ settimane (dal 07/07/2026, commit bbb20b43) **tutti** i run E2E su `develop` e su ogni PR falliscono (~91% degli spec), indipendentemente dal contenuto della PR — non è un problema di questo o quel branch.
- Root cause verificata: `bbb20b43` ha cambiato il default locale di sviluppo in `environment.ts` da `appId: 32, shardName: 'geohub'` a `appId: 1, shardName: 'carg'`. Il workflow `test-e2e.yml` inietta via `sed` solo `appId: 52`, lasciando `shardName` invariato — risultato: CI testa con la combinazione invalida `shardName:'carg' + appId:52` (404 su config.json/icons.json/pois.geojson, 401 su login), confermato dagli screenshot Cypress.
- Fix: iniettare esplicitamente anche `shardName: 'geohub'` (l'ultimo abbinamento noto funzionante con appId 52), scollegando l'ambiente di test CI dal default locale che gli sviluppatori continueranno a modificare per comodità.
- Verificato in locale con Docker (Ubuntu 24.04, stesso runner della CI) che i due comandi `sed` producono `appId: 52` + `shardName: 'geohub'` come atteso.

## Test plan
- [ ] CI E2E verde su questa PR (prima riprova reale della combinazione corretta)

🤖 Generated with [Claude Code](https://claude.com/claude-code)